### PR TITLE
Docs: expand settings integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,262 @@
 # Pomatio Framework
-An easy way to render form fields in WordPress.
 
-## Install
-```
+Pomatio Framework (pom-form) is a WordPress helper library that makes it easy to define admin settings pages and render complex field collections from simple PHP arrays.  This guide walks you through everything you need to start using the framework inside your plugin or theme, including a complete example that mirrors how we integrate it in production.
+
+## Requirements
+
+- PHP 7.4 or higher
+- WordPress 5.0 or higher
+- Composer (to install the package and its autoload file)
+
+## Installation
+
+Install the package in your plugin or theme directory with Composer:
+
+```bash
 composer require pom/form
 ```
 
-## Requirements
-* PHP 7.4 or higher
-* WordPress 5.0 or higher.
-
-## Dependencies
-This package uses the following third party libraries:
-* [jQuery](https://jquery.com/): Version included in WordPress
-* [Bootstrap](https://getbootstrap.com/): v4.6.0
-* [select2](https://select2.org/): v4.0.13
-* [CodeMirror](https://codemirror.net/): Version included in WordPress
-
-## How to use
-To output any field first you need to import the required class:
+If you ship the framework inside a distributed plugin, remember to include Composer’s autoload file before bootstrapping the framework:
 
 ```php
-use PomatioFramework\Pomatio_Framework;
+require_once __DIR__ . '/vendor/autoload.php';
 ```
 
-Example of how to render a field:
+## Project structure example
+
+A minimal plugin that uses Pomatio Framework to render settings might look like this:
+
+```
+wp-content/
+└── plugins/
+    └── pom-ai/
+        ├── admin/
+        │   ├── class-admin.php
+        │   └── settings.php
+        ├── assets/
+        │   ├── css/
+        │   │   └── ai-dashboard.css
+        │   └── js/
+        │       └── ai-dashboard.js
+        ├── settings/
+        │   └── enabled_settings.php
+        ├── vendor/
+        │   └── autoload.php
+        └── pom-ai.php (plugin bootstrap file)
+```
+
+The framework stores run‑time configuration under `wp-content/settings/pomatio-framework/sites/<site-id>/<slug>/`.  In the example above the slug is `pom-ai`, so the file `enabled_settings.php` will be read from `wp-content/settings/pomatio-framework/sites/<site-id>/pom-ai/enabled_settings.php`.
+
+## Step-by-step tutorial
+
+The following walk-through reproduces the behaviour of our internal `POM_AI_Admin_Settings` class.  You can copy the snippets into your own plugin and adjust namespaces, slugs and assets as needed.
+
+### 1. Bootstrap your admin class
+
+Create `admin/class-admin.php` and instantiate it from your plugin’s main file:
 
 ```php
-echo (new Pomatio_Framework())::add_field([
-    'type' => 'text',
-    'label' => 'Test Framework',
-    'description' => 'Lorem ipsum dolor sit amet consectetur adipiscing elit.',
-    'placeholder' => 'Lorem Ipsum', // optional
-    'name' => 'name',
-    'class' => 'regular-text',
-    'value' => '',
-    'description_position' => 'below_label' // optional
-    'default' => '' // optional
-]);
+require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/admin/class-admin.php';
+
+new POM_AI_Admin_Settings();
 ```
 
-## Docs
-The framework is fully documented [here](docs/index.md).
+### 2. Register hooks and load enabled tweaks
+
+Inside `POM_AI_Admin_Settings` add the hooks you need for WordPress and Pomatio Framework.  The snippet below shows how to register scripts, AJAX handlers and dashboard UI pieces.  The important part is calling `PomatioFramework\Pomatio_Framework_Disk::read_file()` to find which tweaks are active and load their `tweak.php` files dynamically.
+
+```php
+use PomatioFramework\Pomatio_Framework_Disk;
+use PomatioFramework\Pomatio_Framework_Settings;
+
+class POM_AI_Admin_Settings {
+    public function __construct() {
+        add_action('admin_footer', [$this, 'dashboard_welcome_banner']);
+        add_action('wp_ajax_pom_ai_get_credits', [$this, 'get_credits']);
+        add_action('admin_enqueue_scripts', [$this, 'enqueue_scripts']);
+
+        add_action('admin_menu', [$this, 'options_menu']);
+        add_action('in_admin_header', [$this, 'pom_ai_render_tabs']);
+
+        $enabled_settings = Pomatio_Framework_Disk::read_file('enabled_settings.php', 'pom-ai', 'array');
+
+        foreach ($enabled_settings as $tweak => $status) {
+            if ($status === '1') {
+                $tweak_path = POM_AI_PLUGIN_PATH . "settings/$tweak/";
+
+                if (file_exists("{$tweak_path}tweak.php")) {
+                    include "{$tweak_path}tweak.php";
+                }
+            }
+        }
+    }
+
+    // ... other methods (enqueue_scripts, get_credits, etc.) ...
+}
+```
+
+`Pomatio_Framework_Disk::read_file()` automatically resolves the correct storage directory for the current site and returns the contents of `enabled_settings.php` as an array, allowing you to enable or disable tweak folders without touching PHP code.
+
+### 3. Register the settings page with WordPress **and** the framework
+
+Use `add_submenu_page()` to create a submenu under “Settings → AI settings”.  Save the return value in `$hook_suffix`, then register that hook with the framework.  This ensures Pomatio Framework can enqueue its assets only when the page is active.
+
+```php
+public function options_menu(): void {
+    $hook_suffix = add_submenu_page(
+        'options-general.php',
+        __('AI settings', POM_AI_PLUGIN_SLUG),
+        __('AI settings', POM_AI_PLUGIN_SLUG),
+        'read',
+        'pom-ai',
+        [$this, 'pom_ai_settings_page']
+    );
+
+    if (class_exists('PomatioFramework\\Pomatio_Framework')) {
+        PomatioFramework\Pomatio_Framework::register_settings_page($hook_suffix);
+    }
+}
+```
+
+### 4. Describe the tabs and fields in `admin/settings.php`
+
+The settings definition file returns an associative array grouped by tab.  You can hide entire groups unless a prerequisite tweak is enabled by checking the `enabled_settings.php` array.
+
+```php
+use PomatioFramework\Pomatio_Framework_Settings;
+use PomatioFramework\Pomatio_Framework_Disk;
+
+$pom_ai_settings['config'] = [
+    'settings_dir' => POM_AI_PLUGIN_PATH . 'settings'
+];
+
+$pom_ai_settings['ai_base_config'] = [
+    'title' => __('AI Setup', POM_AI_PLUGIN_SLUG),
+    'allowed_roles' => ['administrator', 'editor'],
+    'tab' => [
+        'ai_base_config' => [
+            'title' => __('Basic AI setup', POM_AI_PLUGIN_SLUG),
+            'description' => __('Basic configuration for AI tools.', POM_AI_PLUGIN_SLUG),
+            'settings' => [
+                'ai-base-setup' => [
+                    'title' => __('Enable AI tools', POM_AI_PLUGIN_SLUG),
+                    'description' => __('Check this to enable AI features...', POM_AI_PLUGIN_SLUG),
+                    'heading_checkbox' => __('Globally enable AI features', POM_AI_PLUGIN_SLUG),
+                    'label_checkbox' => __('Check this to enable AI features.', POM_AI_PLUGIN_SLUG),
+                    'requires_initialization' => true
+                ],
+            ]
+        ],
+    ]
+];
+
+$enabled_settings = Pomatio_Framework_Disk::read_file('enabled_settings.php', 'pom-ai', 'array');
+
+if (!empty($enabled_settings['ai-base-setup'])) {
+    $pom_ai_settings['pom_ai_api_keys'] = [
+        'title' => __('API keys', POM_AI_PLUGIN_SLUG),
+        'allowed_roles' => ['administrator'],
+        'tab' => [
+            'pom_ai_api_keys' => [
+                'title' => __('POM AI API keys', POM_AI_PLUGIN_SLUG),
+                'description' => __('Here you can setup your API keys...', POM_AI_PLUGIN_SLUG),
+                'settings' => []
+            ],
+        ]
+    ];
+}
+
+return apply_filters('pom_ai_settings', $pom_ai_settings);
+```
+
+Each field definition supports multiple parameters (`title`, `description`, `img`, checkboxes, etc.) that are described in detail in [`docs/index.md`](docs/index.md).
+
+### 5. Override the content of specific tabs
+
+By default, `Pomatio_Framework_Settings::render()` draws every tab and field using the definition array.  If you want to replace the markup of a tab (for example the API keys screen), detect the active tab and output your own HTML before calling the renderer for the rest.
+
+```php
+public function pom_ai_settings_page(): void {
+    $settings_path = require POM_AI_PLUGIN_PATH . 'admin/settings.php';
+    $current_tab = Pomatio_Framework_Settings::get_current_tab($settings_path);
+
+    if ($current_tab === 'pom_ai_api_keys') {
+        // Custom markup, form handling and persistence
+        $pom_ai_keys = get_option('pom_ai_api_keys', '');
+        $keys = explode(':', $pom_ai_keys);
+        $public_key = isset($keys[0]) ? esc_attr($keys[0]) : '';
+        $private_key = isset($keys[1]) ? esc_attr($keys[1]) : '';
+
+        ?>
+        <div id="pom-ai-panel">
+            <p><?php _e('Your site AI credits', POM_AI_PLUGIN_SLUG); ?>:
+                <span id="pom-ai-available-credits" class="spinner"><?php _e('Loading your credits...', POM_AI_PLUGIN_SLUG); ?></span>
+            </p>
+            <hr>
+            <h2><?php _e('POM AI API Keys', POM_AI_PLUGIN_SLUG); ?></h2>
+            <form method="post" action="">
+                <label for="pom_ai_public_key"><?php _e('Public Key', POM_AI_PLUGIN_SLUG); ?></label>
+                <input type="text" name="pom_ai_public_key" id="pom_ai_public_key" value="<?php echo $public_key; ?>" required>
+                <label for="pom_ai_private_key"><?php _e('Private Key', POM_AI_PLUGIN_SLUG); ?></label>
+                <input type="text" name="pom_ai_private_key" id="pom_ai_private_key" value="<?php echo $private_key; ?>" required>
+                <input type="submit" name="pom_ai_save_keys" class="button button-primary" value="<?php _e('Save API Keys', POM_AI_PLUGIN_SLUG); ?>">
+            </form>
+        </div>
+        <?php
+
+        if (isset($_POST['pom_ai_save_keys'])) {
+            $combined_keys = sanitize_text_field($_POST['pom_ai_public_key']) . ':' . sanitize_text_field($_POST['pom_ai_private_key']);
+            update_option('pom_ai_api_keys', $combined_keys);
+            echo "<script>location.replace('" . admin_url('options-general.php?page=pom-ai&section=pom_ai_api_keys') . "');</script>";
+            exit;
+        }
+    } else {
+        Pomatio_Framework_Settings::render('pom-ai', $settings_path);
+    }
+}
+```
+
+### 6. Render tabs in the admin header
+
+To show the framework tab navigation above your page content, hook into `in_admin_header` and call `Pomatio_Framework_Settings::render_tabs()` when the screen ID matches your page slug.
+
+```php
+public function pom_ai_render_tabs(): void {
+    $screen = get_current_screen();
+
+    if (substr($screen->id, -strlen('pom-ai')) === 'pom-ai') {
+        $settings_path = require POM_AI_PLUGIN_PATH . 'admin/settings.php';
+        Pomatio_Framework_Settings::render_tabs('pom-ai', $settings_path);
+    }
+}
+```
+
+### 7. Read saved values anywhere in your code
+
+Once the form is rendered, you can retrieve values using `Pomatio_Framework_Settings::get_setting_value()`.  Pass the framework slug, the tab identifier, the field key and the field type.
+
+```php
+$copyright = Pomatio_Framework_Settings::get_setting_value(
+    'pom-ai',
+    'ai_base_config',
+    'ai-base-setup',
+    'checkbox'
+);
+
+if (!empty($copyright)) {
+    // Do something with the saved value.
+}
+```
+
+### 8. Optional: enqueue assets and AJAX endpoints
+
+You are free to add the scripts, styles and AJAX callbacks your plugin needs.  The example class above enqueues a dashboard panel, fetches API credits via `wp_ajax_pom_ai_get_credits`, and displays a welcome banner on the WordPress dashboard.  Those helpers are standard WordPress code and live alongside the framework integration.
+
+## Next steps
+
+- Browse the [`docs/`](docs/index.md) folder for field definitions and advanced configuration examples.
+- Inspect the `settings/` directory in your plugin to see how tweaks are structured.
+- Combine the settings forms with REST endpoints or background jobs to build rich AI-assisted features.
+
+With these building blocks you can replicate the full POM AI administration experience or adapt it to your own project.

--- a/docs/settings-page.md
+++ b/docs/settings-page.md
@@ -1,16 +1,17 @@
 # Settings page
-Pomatio Framework has a simple tool with which to dynamically generate settings pages.
 
-The framework has a method that, by passing the plugin/theme identifier and the settings array,
-dynamically generates the tabs and fields of each section.
+Pomatio Framework can dynamically generate settings pages for your plugin or theme.  You describe the tabs and fields in a PHP array, register a WordPress admin page, and call the framework helpers to render the UI.
 
-Example of how to generate a settings page within a plugin:
+## Registering the admin page
 
-```PHP
+Create your admin page using `add_submenu_page()` (or any other WordPress admin menu function).  Save the return value in `$hook_suffix` and register it with `PomatioFramework\Pomatio_Framework::register_settings_page()` so the framework knows when to enqueue scripts and styles.
+
+```php
+use PomatioFramework\Pomatio_Framework;
 use PomatioFramework\Pomatio_Framework_Settings;
 
-add_action('admin_menu', function() {
-    add_submenu_page(
+add_action('admin_menu', function () {
+    $hook_suffix = add_submenu_page(
         'options-general.php',
         __('Dummy', 'dummy-slug'),
         __('Dummy', 'dummy-slug'),
@@ -18,14 +19,80 @@ add_action('admin_menu', function() {
         'dummy-slug',
         'dummy_plugin_settings_page'
     );
-});
 
+    Pomatio_Framework::register_settings_page($hook_suffix);
+});
+```
+
+## Rendering the settings form
+
+Inside the page callback, require the file that returns the settings array and pass it to `Pomatio_Framework_Settings::render()`.  The first parameter is the framework slug (usually your plugin slug), and the second is the settings definition array.
+
+```php
 function dummy_plugin_settings_page() {
-    $settings_path = require '/path/to/settings/file.php'; // The value of the variable must be the settings array.
-    Pomatio_Framework_Settings::render(POMATIO_TWEAKS_SLUG, $settings_path);
+    $settings_path = require __DIR__ . '/settings.php';
+    Pomatio_Framework_Settings::render('dummy-slug', $settings_path);
 }
 ```
 
-As shown in the example, we first import the class that the 'render' method is in, 
-and then in the callback of the ```add_submenu_page action```, call the static render function, 
-passing it the two required parameters.
+## Overriding tab content
+
+You can replace the markup of specific tabs while still relying on the framework to render the rest.  Fetch the current tab with `Pomatio_Framework_Settings::get_current_tab()` and conditionally output your own HTML.  For example, this is how we render a custom API key form:
+
+```php
+function dummy_plugin_settings_page() {
+    $settings_path = require __DIR__ . '/settings.php';
+    $current_tab = Pomatio_Framework_Settings::get_current_tab($settings_path);
+
+    if ($current_tab === 'dummy_api_keys') {
+        // Your custom markup and form handling here.
+    } else {
+        Pomatio_Framework_Settings::render('dummy-slug', $settings_path);
+    }
+}
+```
+
+## Rendering the tab navigation
+
+To show the framework tabs above the screen title, hook into `in_admin_header` and call `Pomatio_Framework_Settings::render_tabs()` when the current screen ID matches your settings page.
+
+```php
+add_action('in_admin_header', function () {
+    $screen = get_current_screen();
+
+    if (substr($screen->id, -strlen('dummy-slug')) === 'dummy-slug') {
+        $settings_path = require __DIR__ . '/settings.php';
+        Pomatio_Framework_Settings::render_tabs('dummy-slug', $settings_path);
+    }
+});
+```
+
+## Loading tweak definitions
+
+If you use tweak folders or other modular features, read the `enabled_settings.php` file provided by the Pomatio storage directory and include the corresponding PHP files inside your admin class constructor.
+
+```php
+use PomatioFramework\Pomatio_Framework_Disk;
+
+$enabled_settings = Pomatio_Framework_Disk::read_file('enabled_settings.php', 'dummy-slug', 'array');
+
+foreach ($enabled_settings as $tweak => $status) {
+    if ($status === '1') {
+        $tweak_path = plugin_dir_path(__FILE__) . "settings/$tweak/";
+
+        if (file_exists("{$tweak_path}tweak.php")) {
+            include "{$tweak_path}tweak.php";
+        }
+    }
+}
+```
+
+## Retrieving saved values
+
+Anywhere in your plugin you can access saved settings via `Pomatio_Framework_Settings::get_setting_value()`:
+
+```php
+$value = Pomatio_Framework_Settings::get_setting_value('dummy-slug', 'general', 'feature-toggle', 'checkbox');
+```
+
+Use these helpers to build fully-featured admin experiences backed by Pomatio Framework.


### PR DESCRIPTION
## Summary
- rewrite the main README with a comprehensive tutorial on wiring Pomatio Framework into a plugin, including examples of the admin class, settings file, and tweak loader
- expand the settings page documentation to cover registering the page hook with the framework, overriding tab content, rendering tabs, and loading tweak definitions

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cab77fdcd0832f91b1cde0ef945820