### PR TITLE
docs: expand field and settings documentation

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -1,33 +1,154 @@
 # Fields
 
-| Field                                    | Description                                                                                                                                                                                                                                                                      |
-|------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [Button](fields/button.md)               |                                                                                                                                                                                                                                                                                  |
-| [Checkbox](fields/checkbox.md)           | Allows to render multiple checkboxes at the same time passing them as options parameter. If this option is chosen, the value parameter can be an array to establish as checked more than one checkbox.<br>The checkbox has the value 'yes' if it is selected and 'no' otherwise. |
-| [Code CSS](fields/code-css.md)           | Render a CodeMirror editor with CSS autocomplete and CSS inspection.                                                                                                                                                                                                             |
-| [Code HTML](fields/code-html.md)         | Render a CodeMirror editor with HTML autocomplete and HTML inspection.                                                                                                                                                                                                           |
-| [Code JS](fields/code-js.md)             | Render a CodeMirror editor with JS autocomplete and JS inspection.                                                                                                                                                                                                               |                |                                                                                                                                                                                                                                                                                  |
-| [Color](fields/color.md)                 | Renders the native WordPress color picker.                                                                                                                                                                                                                                       |
-| [Color palette](fields/color-palette.md) | Shows a color picker set using the 'pom_form_color_palette' filter.                                                                                                                                                                                                              |
-| [Date](fields/date.md)                   |                                                                                                                                                                                                                                                                                  |
-| [Datetime](fields/datetime.md)           |                                                                                                                                                                                                                                                                                  |
-| [E-mail](fields/email.md)                |                                                                                                                                                                                                                                                                                  |
-| [File](fields/file.md)                   |                                                                                                                                                                                                                                                                                  |
-| [Gallery](fields/gallery.md)             |                                                                                                                                                                                                                                                                                  |
-| [Hidden](fields/hidden.md)               |                                                                                                                                                                                                                                                                                  |
-| [Icon picker](fields/icon-picker.md)     | Select icons in a simple way among all icon libraries.<br/> It has the filters 'pom_form_icon_libraries' and 'pom_form_icon_libraries_path' to set the libraries.                                                                                                                |
-| [Image picker](fields/image-picker.md)   | Select an image from the media gallery.                                                                                                                                                                                                                                          |
-| [Number](fields/number.md)               |                                                                                                                                                                                                                                                                                  |
-| [Password](fields/password.md)           |                                                                                                                                                                                                                                                                                  |
-| [Quantity](fields/quantity.md)           |                                                                                                                                                                                                                                                                                  |
-| [Radio](fields/radio.md)                 |                                                                                                                                                                                                                                                                                  |
-| [Range](fields/range.md)                 |                                                                                                                                                                                                                                                                                  |
-| [Repeater](fields/repeater.md)           |                                                                                                                                                                                                                                                                                  |
-| [Select](fields/select.md)               | Allows optgroup, compatible with select2 (In the class parameter you have to add the class select2)                                                                                                                                                                              |
-| [Telephone](fields/telephone.md)         |                                                                                                                                                                                                                                                                                  |
-| [Text](fields/text.md)                   |                                                                                                                                                                                                                                                                                  |
-| [Textarea](fields/textarea.md)           |                                                                                                                                                                                                                                                                                  |
-| [Time](fields/time.md)                   |                                                                                                                                                                                                                                                                                  |
-| [Tinymce](fields/tinymce.md)             | This field supports the following specific parameters: textarea_rows (number), teeny (boolean), quicktags (boolean), wpautop (boolean), media_buttons (boolean)                                                                                                                  |
-| [Toggle](fields/toggle.md)               |                                                                                                                                                                                                                                                                                  |
-| [URL](fields/url.md)                     |                                                                                                                                                                                                                                                                                  |
+Every field in Pomatio Framework is declared as a PHP array and rendered by `Pomatio_Framework::add_field()`, which normalises the arguments and locates the matching renderer under `src/Fields`.【F:src/Pomatio_Framework.php†L58-L149】 The framework injects scripts such as CodeMirror, Select2, colour pickers, and repeater helpers on demand based on the field types present in your definition.【F:src/Pomatio_Framework.php†L103-L149】
+
+## Defining fields
+
+The minimum requirement for a field is the `type` (matching a class name in `src/Fields`) and a unique `name`. Optional keys such as `label`, `description`, `default`, and `value` are set to sensible defaults by `parse_args()` so you only override what you need.【F:src/Pomatio_Framework.php†L58-L75】
+
+```php
+[
+    'type'        => 'text',
+    'name'        => 'cta-title',
+    'label'       => __('CTA title', 'demo'),
+    'placeholder' => __('Launch offer…', 'demo'),
+    'description' => __('Shown on the homepage hero.', 'demo'),
+]
+```
+
+## Common parameters
+
+| Key | Purpose |
+|-----|---------|
+| `label`, `description` | Human-friendly text rendered above or below the field; the position defaults to `under_field` but can be switched to `below_label`.【F:src/Pomatio_Framework.php†L61-L75】【F:src/Fields/Text.php†L15-L43】 |
+| `default`, `value` | The renderer prefers a saved `value`, then falls back to `default`, so you can pre-populate fields while letting users overwrite them.【F:src/Fields/Text.php†L26-L36】 |
+| `class`, `id` | Custom classes/IDs appended to the generated markup after being sanitised, handy for styling or JavaScript hooks.【F:src/Pomatio_Framework.php†L65-L69】【F:src/Fields/Textarea.php†L31-L36】 |
+| `disabled` | Pass `true` to render a disabled input without losing the value on save—useful for templates or repeater defaults.【F:src/Fields/Text.php†L10-L44】 |
+| `dependency` | Define conditional logic that is serialised into the `data-dependencies` attribute so JavaScript can hide or show the field based on other values.【F:src/Pomatio_Framework_Helper.php†L27-L41】 |
+
+Because each field posts back under its `name`, `Pomatio_Framework_Save::save_settings()` can detect the field type, run the corresponding sanitizer from `class-sanitize.php`, and persist a clean value to disk.【F:src/Pomatio_Framework_Save.php†L32-L123】【F:src/class-sanitize.php†L9-L360】
+
+## Dependencies
+
+Any field can react to other inputs by providing a `dependency` array. `Pomatio_Framework_Helper::get_dependencies_data_attr()` JSON-encodes the structure and stores it as a data attribute without forcing you to write boilerplate, so repeaters, selects, and custom inputs can all participate in complex flows.【F:src/Pomatio_Framework_Helper.php†L27-L41】【F:src/Fields/Select.php†L10-L41】
+
+## Working with repeaters
+
+The repeater field is a container that renders a list of child fields, supports defaults, cloning, sorting, nested repeaters, and per-item dependencies.【F:src/Fields/Repeater.php†L15-L209】 It stores its configuration alongside the saved values in a hidden input (`data-type="repeater"`), and during sanitisation each nested field is processed with its own sanitizer so code editors are written to disk while plain inputs remain inline.【F:src/Fields/Repeater.php†L210-L254】【F:src/class-sanitize.php†L264-L316】 Useful options include:
+
+- `fields` – Array of child field definitions to render inside each item.
+- `title` – Heading shown in the draggable item header.
+- `limit` – Maximum number of items; the sanitizer honours the limit during the save loop.【F:src/Fields/Repeater.php†L23-L61】【F:src/class-sanitize.php†L273-L280】
+- `defaults` – Seed items that can be restored individually or en masse, including `can_be_removed` flags for mandatory rows.【F:src/Fields/Repeater.php†L62-L118】
+- `cloneable`, `sortable`, `disable_new` – Toggle cloning, drag-and-drop ordering, or the “Add new” button.【F:src/Fields/Repeater.php†L29-L104】【F:src/Fields/Repeater.php†L199-L209】
+
+Inside a repeater you can still use dependencies (`used_for_title` on text fields updates the handle label) and nested repeaters, and when a child is a code editor the framework automatically enqueues CodeMirror before the Ajax templates are requested.【F:src/Fields/Text.php†L23-L44】【F:src/Pomatio_Framework.php†L103-L149】 Nested code editor values are written to files whose paths are stored in the saved JSON, so your callback can read the actual contents later.【F:src/class-sanitize.php†L295-L306】
+
+### Comprehensive repeater example
+
+The snippet below mirrors a real-world permission matrix. It contains nested repeaters, dependencies, WooCommerce lookups, and conditional subscription fields. All of the options come straight from the framework—no custom rendering needed.
+
+```php
+return [
+    [
+        'type'  => 'repeater',
+        'title' => __('Permission rules', POM_THEME_SLUG),
+        'name'  => 'permission_rules',
+        'fields' => [
+            [
+                'type'           => 'Text',
+                'name'           => 'rule_name',
+                'label'          => __('Rule name', POM_THEME_SLUG),
+                'used_for_title' => true,
+            ],
+            [
+                'type'   => 'repeater',
+                'title'  => __('Rule', POM_THEME_SLUG),
+                'name'   => 'rule',
+                'fields' => [
+                    [
+                        'type'           => 'Text',
+                        'name'           => 'rule_name',
+                        'label'          => __('Rule name', POM_THEME_SLUG),
+                        'used_for_title' => true,
+                    ],
+                    [
+                        'type'    => 'select',
+                        'name'    => 'rule_type',
+                        'label'   => __('Rule type', POM_THEME_SLUG),
+                        'options' => $rule_types,
+                        'default' => 'none'
+                    ],
+                    [
+                        'type'       => 'select',
+                        'name'       => 'roles',
+                        'multiple'   => true,
+                        'label'      => __('Roles', POM_THEME_SLUG),
+                        'options'    => pom_get_roles(true),
+                        'dependency' => [[[ 'field' => 'rule_type', 'values' => ['role_is', 'role_is_not'] ]]],
+                    ],
+                    // … additional dependent selects and number fields …
+                ],
+            ],
+            [
+                'type'    => 'select',
+                'name'    => 'condition_between_rules',
+                'label'   => __('Rule type', POM_THEME_SLUG),
+                'options' => [
+                    ''   => __('Set a condition', POM_THEME_SLUG),
+                    'and' => __('AND', POM_THEME_SLUG),
+                    'or'  => __('OR', POM_THEME_SLUG),
+                ],
+                'default' => 'and',
+            ],
+        ],
+    ],
+];
+```
+
+When this structure is posted, `sanitize_pom_form_repeater()` walks each layer, enforces the limit, and delegates to the appropriate sanitizers (`sanitize_pom_form_select`, `sanitize_pom_form_number`, etc.) so the saved JSON mirrors the UI without exposing unsanitised input.【F:src/class-sanitize.php†L264-L327】
+
+## Field reference
+
+The framework ships a broad collection of fields. Use the grouped reference below to pick the right control and learn about its quirks.
+
+### Single-line inputs
+
+Text, Email, Url, Tel, Password, Number, Date, Datetime, and Time all follow the same pattern: they render labelled `<input>` elements, honour placeholders and defaults, propagate dependency attributes, and respect a `disabled` flag.【F:src/Fields/Text.php†L9-L44】【F:src/Fields/Email.php†L9-L42】【F:src/Fields/Url.php†L9-L44】【F:src/Fields/Tel.php†L9-L44】【F:src/Fields/Password.php†L9-L44】【F:src/Fields/Number.php†L9-L44】【F:src/Fields/Date.php†L9-L44】【F:src/Fields/Datetime.php†L9-L44】【F:src/Fields/Time.php†L9-L41】 Their values are cleaned by dedicated sanitizers such as `sanitize_pom_form_text()`, `sanitize_pom_form_email()`, `sanitize_pom_form_url()`, `sanitize_pom_form_tel()`, `sanitize_pom_form_number()`, `sanitize_pom_form_date()`, `sanitize_pom_form_datetime()`, and `sanitize_pom_form_time()` so you can trust the persisted data.【F:src/class-sanitize.php†L108-L160】【F:src/class-sanitize.php†L180-L205】【F:src/class-sanitize.php†L343-L360】
+
+### Multi-line editors
+
+Textarea outputs a plain `<textarea>` and honours dependency metadata, whereas Tinymce wraps `wp_editor()` so you can control toolbar options via `custom_attrs` like `textarea_rows`, `teeny`, `quicktags`, `wpautop`, and `media_buttons`.【F:src/Fields/Textarea.php†L9-L44】【F:src/Fields/Tinymce.php†L10-L45】 Code editors (`code_html`, `code_css`, `code_js`, `code_json`) render CodeMirror-backed textareas, fetch the stored file contents if the value is a path, and enqueue the editor assets automatically.【F:src/Fields/Code_HTML.php†L10-L53】【F:src/Pomatio_Framework.php†L103-L149】 Corresponding sanitizers ensure HTML is KSES-filtered, CSS/JS/JSON are stripped of unsafe content, and CodeMirror values are saved to disk when nested inside repeaters.【F:src/class-sanitize.php†L53-L121】【F:src/class-sanitize.php†L295-L306】
+
+### Choice fields
+
+Checkbox, Radio, Toggle, Select, Range, Quantity, Color, and Color Palette provide rich selection UIs:
+
+- **Checkbox** renders either a single yes/no toggle or multiple checkboxes with an array value, seeding “no” via a hidden input for unchecked states.【F:src/Fields/Checkbox.php†L7-L52】 `sanitize_pom_form_checkbox()` converts the payload into `yes`/`no` strings or an array of selected keys.【F:src/class-sanitize.php†L29-L45】
+- **Radio** and **Radio Icons** output mutually exclusive options, the latter loading SVG icons from disk and providing a restore-default shortcut.【F:src/Fields/Radio.php†L7-L42】【F:src/Fields/Radio_Icons.php†L7-L74】 Both rely on `sanitize_pom_form_radio()`/`sanitize_pom_form_radio_icons()` to strip unwanted characters.【F:src/class-sanitize.php†L215-L224】
+- **Toggle** wraps a styled checkbox with automatic IDs and enqueues the CSS needed for the slider UI.【F:src/Fields/Toggle.php†L9-L49】
+- **Select** supports single or multiple values, optgroups, dependency metadata, and automatically enqueues the Select2-compatible script when used inside repeaters.【F:src/Fields/Select.php†L9-L62】【F:src/Pomatio_Framework.php†L125-L132】 `sanitize_pom_form_select()` stores multi-select choices as comma-separated strings for convenience.【F:src/class-sanitize.php†L319-L326】
+- **Range** renders a slider paired with a numeric input and optional suffix, with helpers to restore the default value.【F:src/Fields/Range.php†L7-L69】 Sanitization allows fractional numbers via `sanitize_pom_form_range()`.【F:src/class-sanitize.php†L227-L231】
+- **Quantity** provides plus/minus controls around a numeric input, enqueuing the JS required to bump the value, while `sanitize_pom_form_quantity()` normalises the number.【F:src/Fields/Quantity.php†L9-L48】【F:src/class-sanitize.php†L209-L212】
+- **Color** and **Color Palette** integrate with the WordPress color picker and custom palette filters, storing hex values through `sanitize_pom_form_color()`/`sanitize_pom_form_color_palette()`.【F:src/Fields/Color.php†L7-L43】【F:src/Fields/Color_Palette.php†L7-L87】【F:src/class-sanitize.php†L96-L105】
+
+### Media pickers and assets
+
+File, Image Picker, Gallery, Icon Picker, Signature, Background Image, Font, and Font Picker are specialised helpers for handling files:
+
+- **File** exposes a simple `<input type="file">` and delegates further processing to your save callback; the default sanitizer allows you to filter file types via WordPress filters.【F:src/Fields/File.php†L7-L30】【F:src/class-sanitize.php†L130-L147】
+- **Image Picker** and **Gallery** open the WordPress media modal, store selected IDs/URLs, and enqueue their own CSS/JS wrappers.【F:src/Fields/Image_Picker.php†L7-L61】【F:src/Fields/Gallery.php†L7-L64】 `sanitize_pom_form_image_picker()` and `sanitize_pom_form_gallery()` ensure URLs are valid and gallery IDs contain only digits/commas.【F:src/class-sanitize.php†L157-L193】
+- **Icon Picker** lists the available icon libraries (filterable via `Pomatio_Framework_Helper::get_icon_libraries()`) and lets the user choose an SVG; the stored value is sanitised as a URL.【F:src/Fields/Icon_Picker.php†L7-L113】【F:src/Pomatio_Framework_Helper.php†L79-L92】【F:src/class-sanitize.php†L164-L179】
+- **Signature** renders a canvas-based signature pad, saves the base64 image via `Pomatio_Framework_Disk::save_signature_image()`, and sanitizes through `sanitize_pom_form_signature()`.【F:src/Fields/Signature.php†L7-L52】【F:src/Pomatio_Framework_Disk.php†L84-L119】【F:src/class-sanitize.php†L329-L333】
+- **Background Image** combines multiple sub-fields (image picker, alignment radios, size selectors) inside a wrapper so you can capture every CSS background property from a single composite field.【F:src/Fields/Background_Image.php†L10-L140】 The posted data is JSON-encoded and decoded by `sanitize_pom_form_background_image()`.【F:src/class-sanitize.php†L9-L21】
+- **Font** uses nested repeaters to collect font families, fallbacks, and variant metadata, delegating each variant to the `Font_Picker` field for file uploads.【F:src/Fields/Font.php†L9-L111】【F:src/Fields/Font_Picker.php†L9-L52】 Font uploads are restricted to the extensions returned by `Pomatio_Framework_Helper::get_allowed_font_types()` and sanitised via `sanitize_pom_form_font()` / `sanitize_pom_form_font_picker()`.【F:src/Pomatio_Framework_Helper.php†L360-L371】【F:src/class-sanitize.php†L233-L260】
+
+### Structural helpers
+
+Button, Hidden, Separator, and Background Image wrappers help you compose the layout around your fields:
+
+- **Button** renders either an `<input type="button">`/`submit` or an `<a>` tag when you pass `link => true`, making it ideal for secondary actions like resets or downloads.【F:src/Fields/Button.php†L7-L31】
+- **Hidden** stores metadata alongside the form without any UI.【F:src/Fields/Hidden.php†L7-L23】
+- **Separator** prints headings and paragraphs to break long forms into digestible sections.【F:src/Fields/Separator.php†L7-L15】
+
+With these building blocks you can mix declarative field definitions, conditional logic, repeaters, and post-save callbacks to construct complex admin interfaces while keeping your PHP code concise and maintainable.

--- a/docs/fields/button.md
+++ b/docs/fields/button.md
@@ -1,2 +1,3 @@
 # Button
-Documentation under development
+
+Button renders either an `<input>` or `<a>` element depending on the `link` flag, making it ideal for custom actions alongside your settings, and the value passes through `sanitize_pom_form_button()` during saving.【F:src/Fields/Button.php†L7-L31】【F:src/class-sanitize.php†L23-L26】 See [Structural helpers](../fields.md#structural-helpers) for more context.

--- a/docs/fields/checkbox.md
+++ b/docs/fields/checkbox.md
@@ -1,2 +1,3 @@
 # Checkbox
-Documentation under development
+
+Checkbox supports both single yes/no toggles and multi-select lists, always posting a hidden “no” value to handle unchecked states and sanitising results through `sanitize_pom_form_checkbox()`.【F:src/Fields/Checkbox.php†L7-L52】【F:src/class-sanitize.php†L29-L45】 See [Choice fields](../fields.md#choice-fields) for examples.

--- a/docs/fields/code-css.md
+++ b/docs/fields/code-css.md
@@ -1,2 +1,3 @@
 # Code CSS
-Documentation under development
+
+The CSS code editor renders a CodeMirror textarea with dependency support, reloads saved files when present, and hands the raw content to `sanitize_pom_form_code_css()` (which you can further extend) before storing or exporting it.【F:src/Fields/Code_CSS.php†L9-L52】【F:src/Pomatio_Framework.php†L103-L149】【F:src/class-sanitize.php†L53-L63】 See [Multi-line editors](../fields.md#multi-line-editors) for the complete reference.

--- a/docs/fields/code-html.md
+++ b/docs/fields/code-html.md
@@ -1,2 +1,3 @@
 # Code HTML
-Documentation under development
+
+The HTML code editor injects a CodeMirror textarea, loads any previously saved file contents, and filters the output with `sanitize_pom_form_code_html()` so only whitelisted markup is stored.【F:src/Fields/Code_HTML.php†L9-L53】【F:src/Pomatio_Framework.php†L103-L149】【F:src/class-sanitize.php†L65-L78】 See [Multi-line editors](../fields.md#multi-line-editors) for advanced configuration.

--- a/docs/fields/code-js.md
+++ b/docs/fields/code-js.md
@@ -1,2 +1,3 @@
 # Code JS
-Documentation under development
+
+The JavaScript code editor loads CodeMirror with the proper settings, reuses saved files when present, and sanitises the payload with `sanitize_pom_form_code_js()` before it is stored or written to disk from within repeaters.【F:src/Fields/Code_JS.php†L9-L52】【F:src/Pomatio_Framework.php†L103-L149】【F:src/class-sanitize.php†L80-L94】 See [Multi-line editors](../fields.md#multi-line-editors) for shared options across code fields.

--- a/docs/fields/code-json.md
+++ b/docs/fields/code-json.md
@@ -1,0 +1,3 @@
+# Code JSON
+
+The JSON code editor works like the other CodeMirror-based fields, preloading saved files and sanitising the content with `sanitize_pom_form_code_json()` before persistence or file export from repeaters.【F:src/Fields/Code_JSON.php†L9-L52】【F:src/Pomatio_Framework.php†L103-L149】【F:src/class-sanitize.php†L88-L94】 See [Multi-line editors](../fields.md#multi-line-editors) for usage patterns.

--- a/docs/fields/color-palette.md
+++ b/docs/fields/color-palette.md
@@ -1,2 +1,3 @@
-# Color palette
-Documentation under development
+# Color Palette
+
+Color Palette displays a set of predefined swatches (optionally with icons) and persists the selection via `sanitize_pom_form_color_palette()`, including a restore-default shortcut when a fallback is provided.【F:src/Fields/Color_Palette.php†L7-L87】【F:src/class-sanitize.php†L102-L105】 See [Choice fields](../fields.md#choice-fields) for configuration examples.

--- a/docs/fields/color.md
+++ b/docs/fields/color.md
@@ -1,2 +1,3 @@
 # Color
-Documentation under development
+
+Color integrates the WordPress colour picker, supports repeater titles, and stores hex values cleaned by `sanitize_pom_form_color()` so you can safely reuse them in CSS.【F:src/Fields/Color.php†L7-L43】【F:src/class-sanitize.php†L96-L99】 See [Choice fields](../fields.md#choice-fields) for usage guidance.

--- a/docs/fields/date.md
+++ b/docs/fields/date.md
@@ -1,2 +1,3 @@
 # Date
-Documentation under development
+
+Date renders an `<input type="date">` with optional defaults and dependency attributes, then normalises the value through `sanitize_pom_form_date()` before it is written to disk.【F:src/Fields/Date.php†L9-L44】【F:src/class-sanitize.php†L108-L114】 See [Single-line inputs](../fields.md#single-line-inputs) for usage guidance.

--- a/docs/fields/datetime.md
+++ b/docs/fields/datetime.md
@@ -1,2 +1,3 @@
 # Datetime
-Documentation under development
+
+Datetime renders an `<input type="datetime-local">` (with defaults and dependencies) and converts the submitted value into a normalised timestamp using `sanitize_pom_form_datetime()` before persistence.【F:src/Fields/Datetime.php†L9-L44】【F:src/class-sanitize.php†L116-L122】 See [Single-line inputs](../fields.md#single-line-inputs) for more information.

--- a/docs/fields/email.md
+++ b/docs/fields/email.md
@@ -1,2 +1,3 @@
 # Email
-Documentation under development
+
+Email renders an `<input type="email">` with placeholder and dependency support, and sanitizes submissions with `sanitize_pom_form_email()` to guarantee a valid address.【F:src/Fields/Email.php†L9-L41】【F:src/class-sanitize.php†L124-L128】 See [Single-line inputs](../fields.md#single-line-inputs) for more context.

--- a/docs/fields/file.md
+++ b/docs/fields/file.md
@@ -1,2 +1,3 @@
 # File
-Documentation under development
+
+File renders a standard file input that honours labels and descriptions while delegating sanitization to `sanitize_pom_form_file()`, which lets you filter maximum sizes and allowed MIME types through WordPress filters.【F:src/Fields/File.php†L7-L30】【F:src/class-sanitize.php†L130-L147】 See [Media pickers and assets](../fields.md#media-pickers-and-assets) for integration advice.

--- a/docs/fields/gallery.md
+++ b/docs/fields/gallery.md
@@ -1,2 +1,3 @@
 # Gallery
-Documentation under development
+
+Gallery opens the media modal in multi-select mode, renders thumbnails for each chosen attachment, and stores their IDs in a hidden input that is sanitised by `sanitize_pom_form_gallery()` to contain only digits and commas.【F:src/Fields/Gallery.php†L7-L64】【F:src/class-sanitize.php†L157-L160】 See [Media pickers and assets](../fields.md#media-pickers-and-assets) for practical tips.

--- a/docs/fields/hidden.md
+++ b/docs/fields/hidden.md
@@ -1,2 +1,3 @@
 # Hidden
-Documentation under development
+
+Hidden fields store metadata alongside your form without any visible UI, using the same default/override logic as other inputs and sanitising values via `sanitize_pom_form_hidden()`.【F:src/Fields/Hidden.php†L7-L23】【F:src/class-sanitize.php†L170-L179】 See [Structural helpers](../fields.md#structural-helpers) for context.

--- a/docs/fields/icon-picker.md
+++ b/docs/fields/icon-picker.md
@@ -1,34 +1,3 @@
-# Icon picker
-Select icons in a simple way among all icon libraries.
+# Icon Picker
 
-The icon selector has the ```pom_form_icon_libraries``` filter to be able to add as many libraries as desired.
-
-An example to add libraries would be the following:
-
-```PHP
-add_filter('pom_form_icon_libraries', 'add_icon_libraries');
-function add_icon_libraries($libraries) {
-    $libraries['test1'] = [
-        'name' => 'Test 1',
-        'path' => '/path/to/icons/dir'
-    ];
-    
-    $libraries['test2'] = [
-        'name' => 'Test 2',
-        'path' => '/path/to/icons/dir'
-    ];
-    
-    return $libraries;
-}
-```
-
-How to render an Icon picker:
-
-```PHP
-echo (new \PomatioFramework\Form())::add_field([
-    'type' => 'icon_picker',
-    'label' => 'Lorem Ipsum',
-    'description' => 'Lorem ipsum dolor sit amet consectetur adipiscing elit.',
-    'name' => 'icon',
-]);
-```
+Icon Picker lists the available icon libraries, previews SVG glyphs, and saves the chosen asset URL while allowing you to filter the libraries via `Pomatio_Framework_Helper::get_icon_libraries()`.【F:src/Fields/Icon_Picker.php†L7-L113】【F:src/Pomatio_Framework_Helper.php†L79-L92】【F:src/class-sanitize.php†L164-L179】 See [Media pickers and assets](../fields.md#media-pickers-and-assets) for configuration guidance.

--- a/docs/fields/image-picker.md
+++ b/docs/fields/image-picker.md
@@ -1,2 +1,3 @@
-# Image picker
-Documentation under development
+# Image Picker
+
+Image Picker opens the WordPress media modal, renders the selected thumbnail, and stores the image URL via `sanitize_pom_form_image_picker()`, which validates the saved URL before use.【F:src/Fields/Image_Picker.php†L7-L61】【F:src/class-sanitize.php†L184-L194】 See [Media pickers and assets](../fields.md#media-pickers-and-assets) for more examples.

--- a/docs/fields/number.md
+++ b/docs/fields/number.md
@@ -1,2 +1,3 @@
 # Number
-Documentation under development
+
+Number renders an HTML5 numeric input that respects defaults, dependencies, and disabled states, with `sanitize_pom_form_number()` ensuring the stored value contains only numeric characters.【F:src/Fields/Number.php†L9-L44】【F:src/class-sanitize.php†L197-L199】 See [Single-line inputs](../fields.md#single-line-inputs) for parameter details.

--- a/docs/fields/password.md
+++ b/docs/fields/password.md
@@ -1,2 +1,3 @@
 # Password
-Documentation under development
+
+Password mirrors the Text field but renders an `<input type="password">` and sanitizes user input with `sanitize_pom_form_password()` before persistence.【F:src/Fields/Password.php†L9-L44】【F:src/class-sanitize.php†L203-L207】 See [Single-line inputs](../fields.md#single-line-inputs) for shared options.

--- a/docs/fields/quantity.md
+++ b/docs/fields/quantity.md
@@ -1,2 +1,3 @@
 # Quantity
-Documentation under development
+
+Quantity wraps a number input with plus/minus controls, honours dependencies and defaults, enqueues its JavaScript helper, and persists the value through `sanitize_pom_form_quantity()` so only numeric data is stored.【F:src/Fields/Quantity.php†L9-L48】【F:src/class-sanitize.php†L209-L212】 See [Choice fields](../fields.md#choice-fields) for configuration ideas.

--- a/docs/fields/radio.md
+++ b/docs/fields/radio.md
@@ -1,2 +1,3 @@
 # Radio
-Documentation under development
+
+Radio renders a group of mutually exclusive options, automatically selecting saved or default values and sanitising the choice with `sanitize_pom_form_radio()` to strip unsafe characters.【F:src/Fields/Radio.php†L7-L42】【F:src/class-sanitize.php†L215-L218】 See [Choice fields](../fields.md#choice-fields) for advanced usage patterns.

--- a/docs/fields/range.md
+++ b/docs/fields/range.md
@@ -1,2 +1,3 @@
 # Range
-Documentation under development
+
+Range combines an HTML5 slider and numeric input, supports step/min/max constraints, and offers a restore-default control, with sanitization handled by `sanitize_pom_form_range()` to allow fractional values.【F:src/Fields/Range.php†L7-L69】【F:src/class-sanitize.php†L227-L231】 See [Choice fields](../fields.md#choice-fields) for usage guidance.

--- a/docs/fields/repeater.md
+++ b/docs/fields/repeater.md
@@ -1,2 +1,3 @@
 # Repeater
-Documentation under development
+
+Repeaters let you define lists of nested field groups that can be cloned, sorted, limited, or seeded with defaults, all while respecting per-field dependencies and nested repeaters.【F:src/Fields/Repeater.php†L15-L209】 Saved values are stored as JSON and cleaned by `sanitize_pom_form_repeater()`, which runs the correct sanitizer for each child field (including writing code-editor content to disk).【F:src/Fields/Repeater.php†L210-L254】【F:src/class-sanitize.php†L264-L316】 See [Working with repeaters](../fields.md#working-with-repeaters) for a full walkthrough and a production-ready example.

--- a/docs/fields/select.md
+++ b/docs/fields/select.md
@@ -1,2 +1,3 @@
 # Select
-Documentation under development
+
+Select renders a dropdown (or multiselect) with support for optgroups, dependency attributes, and automatic Select2 assets when used in repeaters, while `sanitize_pom_form_select()` normalises the saved values as comma-separated lists.【F:src/Fields/Select.php†L9-L62】【F:src/Pomatio_Framework.php†L125-L132】【F:src/class-sanitize.php†L319-L326】 See [Choice fields](../fields.md#choice-fields) for usage notes and examples.

--- a/docs/fields/telephone.md
+++ b/docs/fields/telephone.md
@@ -1,2 +1,3 @@
 # Telephone
-Documentation under development
+
+Telephone renders an `<input type="tel">` with placeholder and dependency support, and validates international numbers using `sanitize_pom_form_tel()` so only well-formed phone numbers are stored.【F:src/Fields/Tel.php†L9-L44】【F:src/class-sanitize.php†L343-L348】 See [Single-line inputs](../fields.md#single-line-inputs) for configuration patterns.

--- a/docs/fields/text.md
+++ b/docs/fields/text.md
@@ -1,2 +1,3 @@
 # Text
-Documentation under development
+
+The Text field renders a single-line `<input>` with optional placeholder, dependency metadata, and repeater title integration, then sanitizes the submitted value with `sanitize_pom_form_text()`.【F:src/Fields/Text.php†L9-L44】【F:src/class-sanitize.php†L351-L355】 See [Single-line inputs](../fields.md#single-line-inputs) for full parameter details and examples.

--- a/docs/fields/textarea.md
+++ b/docs/fields/textarea.md
@@ -1,2 +1,3 @@
 # Textarea
-Documentation under development
+
+Textarea outputs a `<textarea>` element that honours description positioning, dependency metadata, and default values before the content is sanitised with `sanitize_pom_form_textarea()`.【F:src/Fields/Textarea.php†L9-L43】【F:src/class-sanitize.php†L357-L360】 See [Multi-line editors](../fields.md#multi-line-editors) for configuration tips and examples.

--- a/docs/fields/time.md
+++ b/docs/fields/time.md
@@ -1,2 +1,3 @@
 # Time
-Documentation under development
+
+Time renders an `<input type="time">` with support for defaults, dependencies, and disabled states, validating the HH:MM format through `sanitize_pom_form_time()` during persistence.【F:src/Fields/Time.php†L9-L41】【F:src/class-sanitize.php†L371-L376】 See [Single-line inputs](../fields.md#single-line-inputs) for configuration options.

--- a/docs/fields/tinymce.md
+++ b/docs/fields/tinymce.md
@@ -1,2 +1,3 @@
 # TinyMCE
-Documentation under development
+
+The TinyMCE field embeds `wp_editor()` with optional custom attributes (`textarea_rows`, `teeny`, `quicktags`, `wpautop`, `media_buttons`) and sanitises the rich text through `sanitize_pom_form_tinymce()` using the framework’s allowed HTML list.【F:src/Fields/Tinymce.php†L10-L45】【F:src/class-sanitize.php†L379-L384】【F:src/Pomatio_Framework_Helper.php†L130-L200】 See [Multi-line editors](../fields.md#multi-line-editors) for guidance.

--- a/docs/fields/toggle.md
+++ b/docs/fields/toggle.md
@@ -1,3 +1,3 @@
 # Toggle
-Documentation under development
 
+Toggle renders a styled on/off switch backed by a checkbox, posts a hidden “no” value for unchecked states, enqueues the required CSS, and sanitises the setting via `sanitize_pom_form_toggle()`.【F:src/Fields/Toggle.php†L9-L49】【F:src/class-sanitize.php†L47-L50】 See [Choice fields](../fields.md#choice-fields) for examples.

--- a/docs/fields/url.md
+++ b/docs/fields/url.md
@@ -1,2 +1,3 @@
 # URL
-Documentation under development
+
+URL renders an `<input type="url">` and sanitises submissions with `sanitize_pom_form_url()`, which preserves hash anchors while ensuring any external link is a valid URL.【F:src/Fields/Url.php†L9-L44】【F:src/class-sanitize.php†L387-L395】 See [Single-line inputs](../fields.md#single-line-inputs) for usage.

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -1,4 +1,25 @@
 # Helpers
-Helpers are functions that are available for use at any stage of the application cycle.
 
-Any application that uses the framework can have these functions.
+Pomatio Framework exposes several helper classes so you can inspect configuration, generate dependency metadata, and manipulate files without digging into WordPress internals yourself.
+
+## `Pomatio_Framework_Helper`
+
+* **Dependency attributes** – `get_dependencies_data_attr()` converts the `dependency` structure you define in a field into the JSON payload that drives conditional display in JavaScript.【F:src/Pomatio_Framework_Helper.php†L27-L41】
+* **Utility conversions** – Use `convert_array_to_html_attributes()` and `convert_html_attributes_to_array()` to move between associative arrays and attribute strings when you extend the framework.【F:src/Pomatio_Framework_Helper.php†L44-L67】
+* **Runtime helpers** – Functions such as `generate_random_string()`, `write_log()`, and `path_to_url()` help you build dynamic field IDs, debug issues, and turn filesystem paths into public URLs.【F:src/Pomatio_Framework_Helper.php†L69-L128】
+* **Settings lookups** – `get_settings()` returns the raw settings array for a given tab/subsection and `get_allowed_html()` exposes the HTML tags that text editors sanitize against.【F:src/Pomatio_Framework_Helper.php†L130-L200】
+
+## `Pomatio_Framework_Disk`
+
+* **Automatic directories** – `create_settings_dir()` provisions `wp-content/settings/pomatio-framework/<site>/<slug>/` (including `.htaccess`) the first time a page saves values, making the storage multisite-aware.【F:src/Pomatio_Framework_Disk.php†L128-L156】
+* **File serialization** – `generate_file_content()` turns an array into a PHP file with metadata headers, while `save_to_file()` writes arbitrary content such as code editor values and returns the saved path.【F:src/Pomatio_Framework_Disk.php†L170-L212】
+* **Reading and cleanup** – `read_file()` and `delete_file()` give you convenient access to the stored configuration and let you remove generated assets when a tweak is disabled.【F:src/Pomatio_Framework_Disk.php†L214-L241】
+* **Font and signature support** – The constructor hooks into `upload_dir`/`upload_mimes` so custom fonts are stored under `/fonts`, and the signature helpers persist base64 canvases under a locked-down directory.【F:src/Pomatio_Framework_Disk.php†L10-L119】
+
+## `Pomatio_Framework_Settings`
+
+* **Navigation helpers** – `get_current_tab()` and `get_current_subsection()` inspect the current request (or default to the first entries) so you can render context-aware navigation or run callbacks only on the active screen.【F:src/Pomatio_Framework_Settings.php†L10-L34】
+* **Field metadata** – `read_fields()` loads the `fields.php` definition for a given setting, and `is_setting_enabled()` checks `enabled_settings.php` to see whether a tweak is turned on.【F:src/Pomatio_Framework_Settings.php†L36-L65】
+* **Value retrieval** – `get_setting_value()` reads the saved PHP file and optionally re-sanitizes the value using the field type, which is perfect for use in templates or business logic.【F:src/Pomatio_Framework_Settings.php†L46-L59】
+
+Leverage these helpers together with the automatic save routine to keep your own code focused on business logic rather than boilerplate persistence.【F:src/Pomatio_Framework_Save.php†L10-L122】

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,52 @@
 # Pomatio Framework
 
-Here you will find all the documentation you need to be able to use the
-Pomatio Framework in any WordPress project.
+Pomatio Framework lets you describe WordPress admin interfaces with plain PHP arrays and have the library render, validate, and persist every field for you.【F:src/Pomatio_Framework.php†L11-L149】【F:src/Pomatio_Framework_Save.php†L10-L122】 The core bootstrap wires the helper, disk, settings, AJAX, save, and translation services on construction and automatically injects the required assets only on registered settings pages.【F:src/Pomatio_Framework.php†L14-L45】
 
-| Table of Contents |                                        |
-|-------------------|----------------------------------------|
-| Fields            | [Read documentation](fields.md)        |
-| Helpers           | [Read documentation](helpers.md)       |
-| Settings page     | [Read documentation](settings-page.md) |
+## Key features
+
+- **Declarative settings** – Declare tabs, subsections, and fields in PHP arrays and let `Pomatio_Framework_Settings::render()` output the markup and handle form submission.【F:src/Pomatio_Framework_Settings.php†L212-L371】【F:src/Pomatio_Framework_Save.php†L10-L122】
+- **Dozens of reusable fields** – Everything from simple text inputs to repeaters, media pickers, icon pickers, code editors, and background builders are provided as drop-in field types.【F:src/Pomatio_Framework.php†L85-L149】【F:src/Fields/Repeater.php†L15-L209】
+- **Automatic sanitization and persistence** – Each field maps to a sanitizer in `class-sanitize.php`, and the save handler writes enabled settings to the WordPress content directory in a multisite-aware location.【F:src/Pomatio_Framework_Save.php†L19-L123】【F:src/class-sanitize.php†L9-L360】【F:src/Pomatio_Framework_Disk.php†L128-L189】
+- **Conditional logic and nesting** – Any field can declare dependencies and repeaters can contain other repeaters, allowing you to model complex configuration screens without bespoke PHP forms.【F:src/Pomatio_Framework_Helper.php†L27-L41】【F:src/Fields/Repeater.php†L45-L209】
+
+## Quick start
+
+1. **Register your admin page** and tell the framework about the hook suffix so assets load only where they are needed.【F:src/Pomatio_Framework.php†L33-L45】
+2. **Return a settings array** from a PHP file describing your tabs, subsections, and field definitions.
+3. **Render the form** by calling `Pomatio_Framework_Settings::render( $slug, $settings_array )` inside the page callback.【F:src/Pomatio_Framework_Settings.php†L212-L371】
+4. **React after saving** via the `pomatio_framework_after_save_settings` action which fires after sanitization and persistence.【F:src/Pomatio_Framework_Save.php†L78-L122】
+
+A minimal settings callback therefore looks like this:
+
+```php
+use PomatioFramework\Pomatio_Framework;
+use PomatioFramework\Pomatio_Framework_Settings;
+
+add_action('admin_menu', function () {
+    $hook_suffix = add_submenu_page(
+        'options-general.php',
+        __('Demo settings', 'demo-slug'),
+        __('Demo settings', 'demo-slug'),
+        'manage_options',
+        'demo-slug',
+        'demo_settings_page'
+    );
+
+    Pomatio_Framework::register_settings_page($hook_suffix);
+});
+
+function demo_settings_page() {
+    $settings = require __DIR__ . '/settings.php';
+    Pomatio_Framework_Settings::render('demo-slug', $settings);
+}
+```
+
+## Documentation map
+
+| Topic | Description |
+|-------|-------------|
+| [Field reference](fields.md) | Every available field type, shared parameters, and advanced examples (including nested repeaters). |
+| [Helper catalogue](helpers.md) | Utility methods for dependency data attributes, disk helpers, and runtime access to stored values. |
+| [Settings pages](settings-page.md) | How to register tabs, subsections, callbacks, and render navigation. |
+
+Use these guides together with the rich field library in `src/Fields` to assemble sophisticated configuration panels without rebuilding boilerplate each time.【F:src/Pomatio_Framework.php†L85-L149】

--- a/docs/settings-page.md
+++ b/docs/settings-page.md
@@ -1,10 +1,10 @@
 # Settings page
 
-Pomatio Framework can dynamically generate settings pages for your plugin or theme.  You describe the tabs and fields in a PHP array, register a WordPress admin page, and call the framework helpers to render the UI.
+Pomatio Framework can dynamically generate settings pages for your plugin or theme. You describe the tabs and fields in a PHP array, register a WordPress admin page, and call the framework helpers to render the UI and persist values for you.【F:src/Pomatio_Framework_Settings.php†L67-L371】【F:src/Pomatio_Framework_Save.php†L10-L122】
 
 ## Registering the admin page
 
-Create your admin page using `add_submenu_page()` (or any other WordPress admin menu function).  Save the return value in `$hook_suffix` and register it with `PomatioFramework\Pomatio_Framework::register_settings_page()` so the framework knows when to enqueue scripts and styles.
+Create your admin page using `add_submenu_page()` (or any other WordPress admin menu function). Save the return value in `$hook_suffix` and register it with `PomatioFramework\Pomatio_Framework::register_settings_page()` so the framework knows when to enqueue scripts and styles.【F:src/Pomatio_Framework.php†L33-L45】
 
 ```php
 use PomatioFramework\Pomatio_Framework;
@@ -26,7 +26,7 @@ add_action('admin_menu', function () {
 
 ## Rendering the settings form
 
-Inside the page callback, require the file that returns the settings array and pass it to `Pomatio_Framework_Settings::render()`.  The first parameter is the framework slug (usually your plugin slug), and the second is the settings definition array.
+Inside the page callback, require the file that returns the settings array and pass it to `Pomatio_Framework_Settings::render()`. The first parameter is the framework slug (usually your plugin slug), and the second is the settings definition array.【F:src/Pomatio_Framework_Settings.php†L67-L82】
 
 ```php
 function dummy_plugin_settings_page() {
@@ -37,7 +37,7 @@ function dummy_plugin_settings_page() {
 
 ## Overriding tab content
 
-You can replace the markup of specific tabs while still relying on the framework to render the rest.  Fetch the current tab with `Pomatio_Framework_Settings::get_current_tab()` and conditionally output your own HTML.  For example, this is how we render a custom API key form:
+You can replace the markup of specific tabs while still relying on the framework to render the rest. Fetch the current tab with `Pomatio_Framework_Settings::get_current_tab()` and conditionally output your own HTML.【F:src/Pomatio_Framework_Settings.php†L10-L34】 For example, this is how we render a custom API key form:
 
 ```php
 function dummy_plugin_settings_page() {
@@ -54,7 +54,7 @@ function dummy_plugin_settings_page() {
 
 ## Rendering the tab navigation
 
-To show the framework tabs above the screen title, hook into `in_admin_header` and call `Pomatio_Framework_Settings::render_tabs()` when the current screen ID matches your settings page.
+To show the framework tabs above the screen title, hook into `in_admin_header` and call `Pomatio_Framework_Settings::render_tabs()` when the current screen ID matches your settings page.【F:src/Pomatio_Framework_Settings.php†L84-L209】
 
 ```php
 add_action('in_admin_header', function () {
@@ -67,9 +67,28 @@ add_action('in_admin_header', function () {
 });
 ```
 
+## Handling callbacks after saving
+
+Each settings definition can include a custom `callback` key alongside the usual `title`, `description`, and `settings_dir`. After the user saves, Pomatio Framework fires the `pomatio_framework_after_save_settings` action with the page slug, current tab, and subsection so you can inspect the active configuration and execute those callbacks.【F:src/Pomatio_Framework_Save.php†L78-L96】 Use `Pomatio_Framework_Helper::get_settings()` to fetch the current settings array and run any callable you stored under the `callback` key.【F:src/Pomatio_Framework_Helper.php†L130-L141】
+
+```php
+add_action('pomatio_framework_after_save_settings', function ($page_slug, $tab, $subsection) {
+    $settings = require POM_AI_PLUGIN_PATH . 'admin/settings.php';
+    $groups = PomatioFramework\Pomatio_Framework_Helper::get_settings($settings, $tab, $subsection);
+
+    foreach ($groups as $setting_key => $group) {
+        if (!empty($group['callback']) && is_callable($group['callback'])) {
+            call_user_func($group['callback'], $page_slug, $setting_key);
+        }
+    }
+});
+```
+
+This pattern lets you invalidate caches, rebuild derived data, or synchronize external services whenever an admin updates a specific section of your settings page.
+
 ## Loading tweak definitions
 
-If you use tweak folders or other modular features, read the `enabled_settings.php` file provided by the Pomatio storage directory and include the corresponding PHP files inside your admin class constructor.
+If you use tweak folders or other modular features, read the `enabled_settings.php` file provided by the Pomatio storage directory and include the corresponding PHP files inside your admin class constructor.【F:src/Pomatio_Framework_Disk.php†L128-L189】
 
 ```php
 use PomatioFramework\Pomatio_Framework_Disk;
@@ -89,7 +108,7 @@ foreach ($enabled_settings as $tweak => $status) {
 
 ## Retrieving saved values
 
-Anywhere in your plugin you can access saved settings via `Pomatio_Framework_Settings::get_setting_value()`:
+Anywhere in your plugin you can access saved settings via `Pomatio_Framework_Settings::get_setting_value()`.【F:src/Pomatio_Framework_Settings.php†L46-L59】 This method automatically re-sanitizes the value if you provide the field type.
 
 ```php
 $value = Pomatio_Framework_Settings::get_setting_value('dummy-slug', 'general', 'feature-toggle', 'checkbox');


### PR DESCRIPTION
## Summary
- rewrite the docs landing page and helpers catalog to describe the framework services and workflow
- document the settings callbacks action and provide richer instructions for rendering tabs and repeaters
- overhaul every field reference with sanitization notes, dependencies, and real-world repeater example

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cabcbae480832f8f764275af5bdfab