### PR TITLE
Support auto-enabled tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ class POM_AI_Admin_Settings {
         add_action('admin_menu', [$this, 'options_menu']);
         add_action('in_admin_header', [$this, 'pom_ai_render_tabs']);
 
-        $enabled_settings = Pomatio_Framework_Disk::read_file('enabled_settings.php', 'pom-ai', 'array');
+        $settings_definition = require POM_AI_PLUGIN_PATH . 'admin/settings.php';
+        $enabled_settings = Pomatio_Framework_Settings::get_effective_enabled_settings('pom-ai', $settings_definition);
 
         foreach ($enabled_settings as $tweak => $status) {
             if ($status === '1') {
@@ -96,7 +97,7 @@ class POM_AI_Admin_Settings {
 }
 ```
 
-`Pomatio_Framework_Disk::read_file()` automatically resolves the correct storage directory for the current site and returns the contents of `enabled_settings.php` as an array, allowing you to enable or disable tweak folders without touching PHP code.
+`Pomatio_Framework_Settings::get_effective_enabled_settings()` resolves the correct storage directory, merges the stored flags with any tweaks marked `requires_initialization => false`, and returns the up-to-date `enabled_settings.php` array so you can bootstrap modules without touching PHP code.
 
 ### 3. Register the settings page with WordPress **and** the framework
 
@@ -151,7 +152,7 @@ $pom_ai_settings['ai_base_config'] = [
     ]
 ];
 
-$enabled_settings = Pomatio_Framework_Disk::read_file('enabled_settings.php', 'pom-ai', 'array');
+$enabled_settings = Pomatio_Framework_Settings::get_effective_enabled_settings('pom-ai', $pom_ai_settings);
 
 if (!empty($enabled_settings['ai-base-setup'])) {
     $pom_ai_settings['pom_ai_api_keys'] = [

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -19,7 +19,7 @@ Pomatio Framework exposes several helper classes so you can inspect configuratio
 ## `Pomatio_Framework_Settings`
 
 * **Navigation helpers** – `get_current_tab()` and `get_current_subsection()` inspect the current request (or default to the first entries) so you can render context-aware navigation or run callbacks only on the active screen.【F:src/Pomatio_Framework_Settings.php†L10-L34】
-* **Field metadata** – `read_fields()` loads the `fields.php` definition for a given setting, and `is_setting_enabled()` checks `enabled_settings.php` to see whether a tweak is turned on.【F:src/Pomatio_Framework_Settings.php†L36-L65】
+* **Field metadata** – `read_fields()` loads the `fields.php` definition for a given setting, `get_effective_enabled_settings()` merges stored flags with auto-enabled tweaks, and `is_setting_enabled()` can use that data to determine whether a tweak is active.【F:src/Pomatio_Framework_Settings.php†L36-L205】
 * **Value retrieval** – `get_setting_value()` reads the saved PHP file and optionally re-sanitizes the value using the field type, which is perfect for use in templates or business logic.【F:src/Pomatio_Framework_Settings.php†L46-L59】
 
 Leverage these helpers together with the automatic save routine to keep your own code focused on business logic rather than boilerplate persistence.【F:src/Pomatio_Framework_Save.php†L10-L122】

--- a/docs/settings-page.md
+++ b/docs/settings-page.md
@@ -88,12 +88,13 @@ This pattern lets you invalidate caches, rebuild derived data, or synchronize ex
 
 ## Loading tweak definitions
 
-If you use tweak folders or other modular features, read the `enabled_settings.php` file provided by the Pomatio storage directory and include the corresponding PHP files inside your admin class constructor.【F:src/Pomatio_Framework_Disk.php†L128-L189】
+If you use tweak folders or other modular features, call `Pomatio_Framework_Settings::get_effective_enabled_settings()` inside your admin class constructor. The helper loads `enabled_settings.php`, marks any `requires_initialization => false` tweaks as active, and persists the merged result so bootstrapping code sees the default modules immediately.【F:src/Pomatio_Framework_Settings.php†L66-L205】
 
 ```php
-use PomatioFramework\Pomatio_Framework_Disk;
+use PomatioFramework\Pomatio_Framework_Settings;
 
-$enabled_settings = Pomatio_Framework_Disk::read_file('enabled_settings.php', 'dummy-slug', 'array');
+$settings_definition = require plugin_dir_path(__FILE__) . 'settings.php';
+$enabled_settings = Pomatio_Framework_Settings::get_effective_enabled_settings('dummy-slug', $settings_definition);
 
 foreach ($enabled_settings as $tweak => $status) {
     if ($status === '1') {

--- a/src/Pomatio_Framework_Save.php
+++ b/src/Pomatio_Framework_Save.php
@@ -25,9 +25,12 @@ class Pomatio_Framework_Save {
 
         require_once 'class-sanitize.php';
 
+        $current_settings = Pomatio_Framework_Helper::get_settings($settings_file_path, $tab, $subsection);
+
         foreach ($settings_dirs as $dir) {
             $data = [];
             $translatables = [];
+            $setting_definition = $current_settings[$dir] ?? [];
 
             foreach ($_POST as $name => $value) {
                 if (strpos($name, "{$dir}_") === 0) {
@@ -76,6 +79,10 @@ class Pomatio_Framework_Save {
             }
 
             Pomatio_Framework_Translations::register($translatables, $page_slug);
+
+            if (isset($setting_definition['requires_initialization']) && $setting_definition['requires_initialization'] === false) {
+                $data['enabled'] = 'yes';
+            }
 
             (new self)->save_settings_files($page_slug, $dir, $data);
 


### PR DESCRIPTION
## Summary
- add `Pomatio_Framework_Settings::get_effective_enabled_settings()` and reuse it in the renderer so tweaks that skip initialization are treated as enabled by default
- force auto-enabled settings to save an enabled flag, add inline copy for hidden toggles, and update documentation to describe the new helper

## Testing
- php -l src/Pomatio_Framework_Settings.php
- php -l src/Pomatio_Framework_Save.php

------
https://chatgpt.com/codex/tasks/task_e_68caf3854c0c832fb3ade34b6f933ce0