### PR TITLE
Add save_as storage overrides and document usage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ Pomatio Framework lets you describe WordPress admin interfaces with plain PHP ar
 - **Declarative settings** – Declare tabs, subsections, and fields in PHP arrays and let `Pomatio_Framework_Settings::render()` output the markup and handle form submission.【F:src/Pomatio_Framework_Settings.php†L212-L371】【F:src/Pomatio_Framework_Save.php†L10-L122】
 - **Dozens of reusable fields** – Everything from simple text inputs to repeaters, media pickers, icon pickers, code editors, and background builders are provided as drop-in field types.【F:src/Pomatio_Framework.php†L85-L149】【F:src/Fields/Repeater.php†L15-L209】
 - **Automatic sanitization and persistence** – Each field maps to a sanitizer in `class-sanitize.php`, and the save handler writes enabled settings to the WordPress content directory in a multisite-aware location.【F:src/Pomatio_Framework_Save.php†L19-L123】【F:src/class-sanitize.php†L9-L360】【F:src/Pomatio_Framework_Disk.php†L128-L189】
+- **Flexible storage targets** – Add `save_as` to a field to persist it as a theme mod or WordPress option while the framework keeps the admin UI, getters, and translation registry in sync.【F:src/Pomatio_Framework_Save.php†L24-L180】【F:src/Pomatio_Framework_Settings.php†L8-L105】【F:src/Pomatio_Framework_Translations.php†L20-L67】
 - **Conditional logic and nesting** – Any field can declare dependencies and repeaters can contain other repeaters, allowing you to model complex configuration screens without bespoke PHP forms.【F:src/Pomatio_Framework_Helper.php†L27-L41】【F:src/Fields/Repeater.php†L45-L209】
 
 ## Quick start


### PR DESCRIPTION
## Summary
- add optional `save_as` routing so fields can persist via theme mods or standard options instead of PHP files
- teach the settings loader, renderer, and translation bridge to honour the new storage metadata
- document the storage overrides with detailed examples in the README and field reference

## Testing
- php -l src/Pomatio_Framework_Save.php
- php -l src/Pomatio_Framework_Settings.php

------
https://chatgpt.com/codex/tasks/task_e_68cb1bf98e50832fb6a8cdceafebcae7