### PR TITLE
Support label checkbox text on checkbox field

### DIFF
--- a/src/Fields/Checkbox.php
+++ b/src/Fields/Checkbox.php
@@ -43,12 +43,16 @@ class Checkbox {
                 }
             }
 
+            $checkbox_label = $args['label_checkbox'] ?? $args['label'] ?? '';
+
             ?>
 
             <div class="form-group">
                 <input type="hidden" name="<?= $args['name'] ?>" value="no" disabled data-type="checkbox">
                 <input<?= $disabled ?> type="checkbox" id="<?= $args['id'] ?>" name="<?= $args['name'] ?>" value="yes" class="form-check-input form-control <?= $args['class'] ?? '' ?>" <?= $checked ?> data-type="checkbox">
-                <label class="form-check-label" for="<?= $args['id'] ?>"><?= $args['label'] ?></label>
+                <?php if (!empty($checkbox_label)) { ?>
+                    <label class="form-check-label" for="<?= $args['id'] ?>"><?= $checkbox_label ?></label>
+                <?php } ?>
             </div>
 
             <?php


### PR DESCRIPTION
## Summary
- allow single checkbox fields to honour the optional `label_checkbox` argument just like module toggles
- keep the existing label as the default when no specific checkbox label is provided

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbe7ca8c50832fb7535fb79e3b13c0