### PR TITLE
Ensure TRBL sync control renders and updates

### DIFF
--- a/src/Fields/Trbl.php
+++ b/src/Fields/Trbl.php
@@ -47,9 +47,12 @@ class Trbl {
 
         echo '<div class="' . implode(' ', $wrapper_classes) . '"' . $data_dependencies . '>';
 
-        if (!empty($args['label'])) {
+        if (!empty($args['label']) || $sync_enabled) {
             echo '<div class="pomatio-trbl__header">';
-            echo '<label for="' . $args['id'] . '">' . $args['label'] . '</label>';
+
+            if (!empty($args['label'])) {
+                echo '<label for="' . $args['id'] . '">' . $args['label'] . '</label>';
+            }
 
             if ($sync_enabled) {
                 $sync_label = $sync_active ? __('Values are locked', 'pomatio-framework') : __('Values are independent', 'pomatio-framework');

--- a/src/dist/js/trbl.js
+++ b/src/dist/js/trbl.js
@@ -26,9 +26,12 @@
         $button.toggleClass('is-locked', locked);
         $button.toggleClass('is-unlocked', !locked);
         $button.attr('aria-pressed', locked ? 'true' : 'false');
-        $button.find('.dashicons')
-            .toggleClass('dashicons-lock', locked)
+        const $icon = $button.find('.dashicons');
+        $icon.toggleClass('dashicons-lock', locked)
             .toggleClass('dashicons-unlock', !locked);
+
+        const label = locked ? 'Values are locked' : 'Values are independent';
+        $button.attr('aria-label', label);
         $state.val(locked ? 'yes' : 'no');
 
         if (locked) {

--- a/src/dist/js/trbl.min.js
+++ b/src/dist/js/trbl.min.js
@@ -26,9 +26,12 @@
         $button.toggleClass('is-locked', locked);
         $button.toggleClass('is-unlocked', !locked);
         $button.attr('aria-pressed', locked ? 'true' : 'false');
-        $button.find('.dashicons')
-            .toggleClass('dashicons-lock', locked)
+        const $icon = $button.find('.dashicons');
+        $icon.toggleClass('dashicons-lock', locked)
             .toggleClass('dashicons-unlock', !locked);
+
+        const label = locked ? 'Values are locked' : 'Values are independent';
+        $button.attr('aria-label', label);
         $state.val(locked ? 'yes' : 'no');
 
         if (locked) {


### PR DESCRIPTION
## Summary
- ensure the TRBL header renders whenever syncing is enabled so the lock toggle is always displayed
- update TRBL sync toggle icon and aria-label when locking/unlocking to reflect current state

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928162a19dc832fa9438d3a61cdfa91)