### PR TITLE
Fix repeater radio groups and dependency handling

### DIFF
--- a/src/Fields/Color_Palette.php
+++ b/src/Fields/Color_Palette.php
@@ -2,6 +2,8 @@
 
 namespace PomatioFramework\Fields;
 
+use PomatioFramework\Pomatio_Framework_Helper;
+
 class Color_Palette {
 
     public static function render_field(array $args): void {
@@ -25,7 +27,10 @@ class Color_Palette {
             $value = $args['default'];
         }
 
-        echo '<div class="color-palette-wrapper">';
+        $data_dependencies = Pomatio_Framework_Helper::get_dependencies_data_attr($args);
+        $unique_field_name = $args['name'] . '_' . Pomatio_Framework_Helper::generate_random_string(6, false);
+
+        echo '<div class="color-palette-wrapper"' . $data_dependencies . ' data-base-name="' . esc_attr($args['name']) . '">';
 
         if (!empty($colors)) {
             $i = 0;
@@ -35,7 +40,7 @@ class Color_Palette {
 
                 ?>
 
-                <input type="radio" name="<?= $args['name'] ?>" id="<?= $args['name'] . '_' . $i ?>" value="<?= $color_slug ?>" <?= $checked ?>>
+                <input type="radio" name="<?= $unique_field_name ?>" data-base-name="<?= esc_attr($args['name']) ?>" id="<?= $args['name'] . '_' . $i ?>" value="<?= $color_slug ?>" <?= $checked ?><?= $data_dependencies ?>>
                 <label style="background-color: <?= $color_data['hex'] ?? '#f3f3f3' ?>" for="<?= $args['name'] . '_' . $i ?>">
 
                     <?php

--- a/src/Fields/Radio_Icons.php
+++ b/src/Fields/Radio_Icons.php
@@ -2,6 +2,8 @@
 
 namespace PomatioFramework\Fields;
 
+use PomatioFramework\Pomatio_Framework_Helper;
+
 class Radio_Icons {
 
     public static function render_field(array $args): void {
@@ -19,9 +21,12 @@ class Radio_Icons {
             $value = $args['default'];
         }
 
+        $data_dependencies = Pomatio_Framework_Helper::get_dependencies_data_attr($args);
+        $unique_field_name = $args['name'] . '_' . Pomatio_Framework_Helper::generate_random_string(6, false);
+
         ?>
 
-        <div class="pomatio-framework-radio-icons-wrapper">
+        <div class="pomatio-framework-radio-icons-wrapper"<?= $data_dependencies ?> data-base-name="<?= esc_attr($args['name']) ?>">
 
             <?php
 
@@ -37,7 +42,7 @@ class Radio_Icons {
                     ?>
 
                     <label class="icon-wrapper">
-                        <input type="radio" id="<?= $args['name'] . '-' . $radio_value ?>" name="<?= $args['name'] ?>" value="<?= $radio_value ?>" class="form-check-input form-control <?= $args['class'] ?? '' ?>" <?= $checked ?> data-type="radio_icons">
+                        <input type="radio" id="<?= $args['name'] . '-' . $radio_value ?>" name="<?= $unique_field_name ?>" data-base-name="<?= esc_attr($args['name']) ?>" value="<?= $radio_value ?>" class="form-check-input form-control <?= $args['class'] ?? '' ?>" <?= $checked ?> data-type="radio_icons"<?= $data_dependencies ?>>
                         <span class="label">
                             <span class="icon"><?= $icon ?></span>
                             <span class="description"><?= $radio_data['label'] ?></span>
@@ -70,7 +75,7 @@ class Radio_Icons {
         echo '</div>';
 
         wp_enqueue_style('pomatio-framework-radio_icons', POM_FORM_SRC_URI . '/dist/css/radio-icons.min.css');
-        wp_enqueue_script('pomatio-framework-color-palette',  POM_FORM_SRC_URI . '/dist/js/radio_icons' . POMATIO_MIN . '.js', [], null, true);
+        wp_enqueue_script('pomatio-framework-radio_icons',  POM_FORM_SRC_URI . '/dist/js/radio_icons' . POMATIO_MIN . '.js', [], null, true);
     }
 
 }

--- a/src/dist/js/color_palette.min.js
+++ b/src/dist/js/color_palette.min.js
@@ -1,1 +1,7 @@
-jQuery((function(e){e(document).on("click",".restore-color-palette",(function(){let t=e(this),c=t.attr("data-default");t.closest(".color-palette-wrapper").find('input[value="'+c+'"]').prop("checked","checked")}))}));
+jQuery(function($) {
+  $(document).on('click', '.restore-color-palette', function() {
+    let $this = $(this);
+    let $default = $this.attr('data-default');
+    $this.closest('.color-palette-wrapper').find('input[value="' + $default + '"]').prop('checked', 'checked');
+  });
+});

--- a/src/dist/js/radio_icons.min.js
+++ b/src/dist/js/radio_icons.min.js
@@ -1,1 +1,7 @@
-jQuery((function(e){e(document).on("click",".restore-radio-icon",(function(){let o=e(this),t=o.attr("data-default");o.closest(".pomatio-framework-radio-icons-wrapper").find('input[value="'+t+'"]').prop("checked","checked")}))}));
+jQuery(function($) {
+  $(document).on('click', '.restore-radio-icon', function() {
+    let $this = $(this);
+    let $default = $this.attr('data-default');
+    $this.closest('.pomatio-framework-radio-icons-wrapper').find('input[value="' + $default + '"]').prop('checked', 'checked');
+  });
+});

--- a/src/dist/js/repeater.js
+++ b/src/dist/js/repeater.js
@@ -18,8 +18,21 @@ jQuery(function($) {
         for (let condition of group) {
           let fieldName = condition.field;
           fieldName = fieldName.replace('field_', '');
-          const $dependentField = $repeaterWrapper.find(`[name="${fieldName}"]`);
-          const fieldValue = $dependentField.val();
+          const selector = `[data-base-name="${fieldName}"]`;
+          let $dependentField = $repeaterWrapper.find(selector);
+
+          if (!$dependentField.length) {
+            $dependentField = $repeaterWrapper.find(`[name="${fieldName}"]`);
+          }
+
+          let fieldValue = '';
+
+          if ($dependentField.is(':radio')) {
+            fieldValue = $dependentField.filter(':checked').val() || '';
+          }
+          else {
+            fieldValue = $dependentField.first().val();
+          }
 
           // If any condition fails, mark as false
           if (!condition.values.includes(fieldValue)) {
@@ -133,7 +146,7 @@ jQuery(function($) {
       // For each field inside the repeater element
       for (let $i2 = 0; $i2 < $repeater_fields.length; $i2++) {
         let $field = $repeater_fields[$i2];
-        let $field_name = $field.getAttribute('name');
+        let $field_name = $field.getAttribute('data-base-name') || $field.getAttribute('name');
         let $is_child_repeater_field = $($field).parents('.repeater-wrapper').length > 1;
 
         /**
@@ -148,6 +161,10 @@ jQuery(function($) {
           $obj[$field_name] = $field.value.trim();
         }
         else {
+          if ($field.type === 'radio' && !$field.checked) {
+            continue;
+          }
+
           let $field_value = $field.value.trim();
           if ($field.getAttribute('data-type') === 'checkbox' || $field.getAttribute('data-type') === 'toggle') {
             $field_value = $($field).is(':checked') ? 'yes' : 'no';

--- a/src/dist/js/repeater.min.js
+++ b/src/dist/js/repeater.min.js
@@ -1,1 +1,583 @@
-jQuery((function(e){function handleFieldVisibility(t){if(t.getAttribute("data-dependencies")){let r=t.getAttribute("data-dependencies");r=r.replaceAll("'",'"');let a=JSON.parse(r),i=e(t).closest(".repeater"),n=!1;for(let e of a){let t=!0;for(let r of e){let e=r.field;e=e.replace("field_","");const a=i.find(`[name="${e}"]`).val();if(!r.values.includes(a)){t=!1;break}}if(t){n=!0;break}}n?e(t).closest(".form-group").show():e(t).closest(".form-group").hide()}}function initializeFieldVisibility(){e(".repeater").each((function(){e(this).find("input, select, textarea").each((function(){handleFieldVisibility(this)}))}))}initializeFieldVisibility(),e(document).on("click",".repeater .title",(function(){e(this).closest(".repeater").toggleClass("closed"),e(".CodeMirror").each((function(e,t){t.CodeMirror.refresh()}))})),e(document).on("click touchstart",".repeater-identifier",(function(t){t.preventDefault(),t.stopPropagation();const r=e(this).text().trim();if(!r)return;if(navigator.clipboard&&navigator.clipboard.writeText)return void navigator.clipboard.writeText(r);const a=e("<textarea>");a.val(r),e(this).append(a),a[0].select(),document.execCommand("copy"),a.remove()}));let $set_repeater_identifier=function(e){let t=e.find(".title .repeater-identifier");if(!t.length)return;let r=e.find('input[name="repeater_identifier"]').val();r?t.html(" - ID: "+r):t.html("")},$update_repeater=function(t){let r=t.children(".repeater"),a=t.parents(".repeater-wrapper").length>0,i={};for(let n=0;n<r.length;n++){let o=r[n].classList.contains("default")?"default":"new";$set_repeater_identifier(e(r[n]));let l=r[n].querySelectorAll("input, select, textarea"),p={},s={};for(let t=0;t<l.length;t++){let r=l[t],i=r.getAttribute("name"),n=e(r).parents(".repeater-wrapper").length>1;if("config"!==i&&(a||!n)){if("repeater_identifier"===i||"default_values"===i)p[i]=r.value.trim();else{let t=r.value.trim();if("checkbox"!==r.getAttribute("data-type")&&"toggle"!==r.getAttribute("data-type")||(t=e(r).is(":checked")?"yes":"no"),"select"===r.getAttribute("data-type")&&e(r).prop("multiple")&&(t=e(r).val().join(",")),"font_picker"===r.getAttribute("data-type")){let e=i.match(/\[(.*)\]/)[1];i=i.split("[")[0],s.hasOwnProperty(e)||(s[e]=t),t=s}p[i]={value:t,type:r.getAttribute("data-type")||""}}handleFieldVisibility(r)}}if(i.hasOwnProperty(o)||(i[o]=[]),i[o].push(p),t.children(".repeater-value").val(JSON.stringify(i)),a){const e=t.closest(".repeater").index(),r=t.find(".repeater-value").attr("name"),a=t.parents(".repeater-wrapper").last(),n=a.find(".repeater").hasClass("new")?"new":"default";let o=a.find(".repeater-value").last().val();o=JSON.parse(o),o.hasOwnProperty(n)||(o[n]=[]),o[n].hasOwnProperty(e)||(o[n][e]=[]),o[n][e].hasOwnProperty(r)||(o[n][e][r]=[]),o[n][e][r]={value:i,type:"repeater"},a.find(".repeater-value").last().val(JSON.stringify(o))}}};e(document).on("click",".add-new-repeater-item",(function(t){t.preventDefault();let r=e(this),a=r.closest(".repeater-wrapper"),i=parseInt(a.attr("data-limit")),n=a.find("> .repeater").length;if(n>=i)return e(".repeater-limit-warning").length||r.after('<span class="repeater-limit-warning">'+pomatio_framework_repeater.limit+"</span>"),void setTimeout((function(){e(".repeater-limit-warning").remove()}),2e3);let o=r.siblings(".repeater-spinner");o.show();let l=r.siblings('[name="config"]').val();e.ajax({url:pomatio_framework_repeater.ajax_url,type:"POST",data:{action:"pomatio_framework_get_repeater_item_html",config:l,items:n},success:function(e){r.before(e),o.hide()}}),e(document).ajaxComplete((function(){void 0!==e.fn.select2&&e(".pomatio-framework-select.multiple").select2(),void 0!==e.fn.wpColorPicker&&e(".pomatio-framework-color-picker").wpColorPicker(),initializeFieldVisibility()}))})),e(document).on("click",".repeater-wrapper .delete",(function(t){if(t.preventDefault(),!confirm(pomatio_framework_repeater.delete_repeater))return;const r=e(this),a=r.closest(".repeater").hasClass("default")?"default":"new",i=r.closest(".repeater-wrapper");if(!(i.parents(".repeater-wrapper").length>0)){const e=r.closest(".repeater").index();let t=i.find(".repeater-value").last().val();return t=JSON.parse(t),t[a].splice(e,1),i.find(".repeater-value").last().val(JSON.stringify(t)),r.closest(".repeater").remove(),void $update_repeater(i)}i.find(".repeater-value").val(""),r.closest(".repeater").remove(),$update_repeater(i)})),e(document).on("change",".repeater-wrapper input, .repeater-wrapper textarea, .repeater-wrapper select",(function(){const t=e(this);$update_repeater(t.closest(".repeater-wrapper"))})),e(document).on("input",'.repeater-wrapper input[data-type="icon_picker"]',(function(){const t=e(this);$update_repeater(t.closest(".repeater-wrapper"))})),void 0!==e.fn.wpColorPicker&&(e(".pomatio-framework-color-picker").wpColorPicker({change:function(t,r){let a=r.color.toString(),i=e(t.target);i.val(a),$update_repeater(i.closest(".repeater-wrapper"))}}),e(document).ajaxComplete((function(){e(".pomatio-framework-color-picker").wpColorPicker({change:function(t,r){let a=r.color.toString(),i=e(t.target);i.val(a),$update_repeater(i.closest(".repeater-wrapper"))}})}))),void 0!==e.fn.sortable&&e(".repeater-wrapper.sortable").sortable({update:function(t,r){$update_repeater(e(this))}});let $update_repeater_title=function(t){let r=t.closest(".repeater").find(".title span").first(),a=function(t){if(t.is("select")){let r=t.find("option:selected");return r.length>0?r.map((function(){return e(this).text().trim()})).get().filter((function(e){return""!==e})).join(", "):""}return t.val()}(t);a?r.html(" - "+a):r.html("")};e(document).on("keyup change",".repeater .use-for-title",(function(){$update_repeater_title(e(this))}));let $append_to_title=function(){e(".repeater-wrapper .use-for-title").each((function(t,r){$update_repeater_title(e(this))})),e(".repeater-wrapper .repeater").each((function(){$set_repeater_identifier(e(this))}))};$append_to_title(),e(document).ajaxComplete((function(){$append_to_title()})),e(document).on("click",".restore-default",(function(t){t.preventDefault();let r=e(this),a=r.closest(".repeater-wrapper"),i=r.closest(".repeater").find('input[name="default_values"').val();if(i){let e=JSON.parse(i);Object.keys(e).map((function(t){let a=e[t].value;r.closest(".repeater").find("input, select, checkbox, textarea").each((function(){this.getAttribute("name")===t&&(this.value=a)}))})),$update_repeater(a)}})),e(document).on("click",".restore-repeater-defaults",(function(t){if(t.preventDefault(),!confirm(pomatio_framework_repeater.restore_msg))return;let r=e(this),a=r.closest(".repeater-wrapper"),i=r.closest(".repeater-wrapper").find(".repeater-spinner");i.show(),a.find(".repeater.default").remove(),e.ajax({url:ajaxurl,type:"POST",data:{action:"pomatio_framework_restore_repeater_defaults",defaults:r.attr("data-defaults"),fields:r.attr("data-fields"),title:r.attr("data-title")},success:function(e){r.closest(".repeater-wrapper").prepend(e),i.hide(),$update_repeater(a)}})})),e(document).on("click",".clone-repeater",(function(t){t.preventDefault();let r=e(this),a=r.closest(".repeater"),i=r.closest(".repeater-wrapper"),n=a.clone();n.find('input[name="repeater_identifier"]').val($generate_random_string(10,!1)),$set_repeater_identifier(n);let o=n.find(".pomatio-framework-code-editor-html, .pomatio-framework-code-editor-js, .pomatio-framework-code-editor-css");for(let t=0;t<o.length;t++)o[t].id=$generate_random_string(10,!1),e(o).next().remove(),wp.codeEditor.initialize(o[t],settings.codeMirrorSettings);n.hasClass("default")&&(n=n.removeClass("default").addClass("new"),n.find('input[name="default_values"]').remove()),a.after(n),$update_repeater(i)}));let $generate_random_string=function(e=10,t=!0){const r=(t?"0123456789":"")+"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";let a="";for(let t=0;t<e;t++)a+=r[Math.floor(Math.random()*r.length)];return a}}));
+/**
+ * @var pomatio_framework_repeater Object containing the translation strings.
+ */
+
+jQuery(function($) {
+  function handleFieldVisibility($field) {
+    if ($field.getAttribute('data-dependencies')) {
+      let json = $field.getAttribute('data-dependencies');
+      json = json.replaceAll('\'', '"');
+
+      let dependencies = JSON.parse(json);
+      let $repeaterWrapper = $($field).closest('.repeater');
+      let groupConditionsMet = false;
+
+      for (let group of dependencies) {
+        let allConditionsMet = true;
+
+        for (let condition of group) {
+          let fieldName = condition.field;
+          fieldName = fieldName.replace('field_', '');
+          const selector = `[data-base-name="${fieldName}"]`;
+          let $dependentField = $repeaterWrapper.find(selector);
+
+          if (!$dependentField.length) {
+            $dependentField = $repeaterWrapper.find(`[name="${fieldName}"]`);
+          }
+
+          let fieldValue = '';
+
+          if ($dependentField.is(':radio')) {
+            fieldValue = $dependentField.filter(':checked').val() || '';
+          }
+          else {
+            fieldValue = $dependentField.first().val();
+          }
+
+          // If any condition fails, mark as false
+          if (!condition.values.includes(fieldValue)) {
+            allConditionsMet = false;
+            break;
+          }
+        }
+
+        // If all conditions in the group are met, set groupConditionsMet to true
+        if (allConditionsMet) {
+          groupConditionsMet = true;
+          break;
+        }
+      }
+
+      if (groupConditionsMet) {
+        $($field).closest('.form-group').show();
+      }
+      else {
+        $($field).closest('.form-group').hide();
+      }
+    }
+  }
+
+  /**
+   * Function to initialize the visibility handling for all fields
+   */
+  function initializeFieldVisibility() {
+    $('.repeater').each(function() {
+      let $repeater_fields = $(this).find('input, select, textarea');
+      $repeater_fields.each(function() {
+        handleFieldVisibility(this);
+      });
+    });
+  }
+
+  /**
+   * Manage dependent fields on page load.
+   */
+  initializeFieldVisibility();
+
+  /**
+   * Toggle the repeater
+   */
+  $(document).on('click', '.repeater .title', function() {
+    $(this).closest('.repeater').toggleClass('closed');
+
+    $('.CodeMirror').each(function(i, el) {
+      el.CodeMirror.refresh();
+    });
+  });
+
+  $(document).on('click touchstart', '.repeater-identifier', function(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const identifier = $(this).text().trim();
+
+    if (!identifier) {
+      return;
+    }
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(identifier);
+      return;
+    }
+
+    const $tempInput = $('<textarea>');
+    $tempInput.val(identifier);
+    $(this).append($tempInput);
+    $tempInput[0].select();
+    document.execCommand('copy');
+    $tempInput.remove();
+  });
+
+  let $set_repeater_identifier = function($repeater) {
+    let $identifier_holder = $repeater.find('.title .repeater-identifier');
+
+    if (!$identifier_holder.length) {
+      return;
+    }
+
+    let $identifier = $repeater.find('input[name="repeater_identifier"]').val();
+
+    if ($identifier) {
+      $identifier_holder.html(' - ID: ' + $identifier);
+    }
+    else {
+      $identifier_holder.html('');
+    }
+  };
+
+  let $update_repeater = function($wrapper) {
+    let $repeater_elements = $wrapper.children('.repeater');
+    let $is_child_repeater = $wrapper.parents('.repeater-wrapper').length > 0;
+
+    let $value = {};
+
+    // For each repeater element
+    for (let $i = 0; $i < $repeater_elements.length; $i++) {
+      let $is_default = $repeater_elements[$i].classList.contains('default');
+      let $repeater_type = $is_default ? 'default' : 'new';
+
+      $set_repeater_identifier($($repeater_elements[$i]));
+
+      let $repeater_fields = $repeater_elements[$i].querySelectorAll('input, select, textarea');
+      let $obj = {};
+
+      let $font_input_val = {};
+
+      // For each field inside the repeater element
+      for (let $i2 = 0; $i2 < $repeater_fields.length; $i2++) {
+        let $field = $repeater_fields[$i2];
+        let $field_name = $field.getAttribute('data-base-name') || $field.getAttribute('name');
+        let $is_child_repeater_field = $($field).parents('.repeater-wrapper').length > 1;
+
+        /**
+         * Exclude config hidden field and
+         * inner repeater fields in main repeater.
+         */
+        if ($field_name === 'config' || (!$is_child_repeater && $is_child_repeater_field)) {
+          continue;
+        }
+
+        if ($field_name === 'repeater_identifier' || $field_name === 'default_values') {
+          $obj[$field_name] = $field.value.trim();
+        }
+        else {
+          if ($field.type === 'radio' && !$field.checked) {
+            continue;
+          }
+
+          let $field_value = $field.value.trim();
+          if ($field.getAttribute('data-type') === 'checkbox' || $field.getAttribute('data-type') === 'toggle') {
+            $field_value = $($field).is(':checked') ? 'yes' : 'no';
+          }
+
+          if ($field.getAttribute('data-type') === 'select' && $($field).prop('multiple')) {
+            $field_value = $($field).val().join(',');
+          }
+
+          if ($field.getAttribute('data-type') === 'font_picker') {
+            let $font_type = $field_name.match(/\[(.*)\]/)[1];
+            $field_name = $field_name.split('[')[0];
+
+            if (!$font_input_val.hasOwnProperty($font_type)) {
+              $font_input_val[$font_type] = $field_value;
+            }
+
+            $field_value = $font_input_val;
+          }
+
+          $obj[$field_name] = {
+            'value': $field_value,
+            'type': $field.getAttribute('data-type') || ''
+          };
+        }
+
+        /**
+         * Manage dependent fields.
+         */
+        handleFieldVisibility($field);
+      }
+
+      /**
+       * If the type exists add it, if it doesn't exist, create it first.
+       */
+      if ($value.hasOwnProperty($repeater_type)) {
+        $value[$repeater_type].push($obj);
+      }
+      else {
+        $value[$repeater_type] = [];
+        $value[$repeater_type].push($obj);
+      }
+
+      $wrapper.children('.repeater-value').val(JSON.stringify($value));
+
+      /**
+       * Appends the content of possible child repeaters to the parent repeater.
+       */
+      if ($is_child_repeater) {
+        const $parent_index = $wrapper.closest('.repeater').index();
+        const $child_repeater_name = $wrapper.find('.repeater-value').attr('name');
+        const $parent_repeater = $wrapper.parents('.repeater-wrapper').last();
+        const $parent_repeater_type = $parent_repeater.find('.repeater').hasClass('new') ? 'new' : 'default';
+        let $parent_value = $parent_repeater.find('.repeater-value').last().val();
+
+        $parent_value = JSON.parse($parent_value);
+
+        if (!$parent_value.hasOwnProperty($parent_repeater_type)) {
+          $parent_value[$parent_repeater_type] = [];
+        }
+
+        if (!$parent_value[$parent_repeater_type].hasOwnProperty($parent_index)) {
+          $parent_value[$parent_repeater_type][$parent_index] = [];
+        }
+
+        if (!$parent_value[$parent_repeater_type][$parent_index].hasOwnProperty($child_repeater_name)) {
+          $parent_value[$parent_repeater_type][$parent_index][$child_repeater_name] = [];
+        }
+
+        $parent_value[$parent_repeater_type][$parent_index][$child_repeater_name] = {
+          'value': $value,
+          'type': 'repeater'
+        };
+
+        $parent_repeater.find('.repeater-value').last().val(JSON.stringify($parent_value));
+      }
+    }
+  };
+
+  /**
+   * Add new repeater element.
+   */
+  $(document).on('click', '.add-new-repeater-item', function(e) {
+    e.preventDefault();
+
+    let $this = $(this);
+
+    let $wrapper = $this.closest('.repeater-wrapper');
+    let $limit = parseInt($wrapper.attr('data-limit'));
+    let $item_count = $wrapper.find('> .repeater').length;
+
+    if ($item_count >= $limit) {
+      if (!$('.repeater-limit-warning').length) {
+        $this.after('<span class="repeater-limit-warning">' + pomatio_framework_repeater.limit + '</span>');
+      }
+
+      setTimeout(function() {
+        $('.repeater-limit-warning').remove();
+      }, 2000);
+
+      return;
+    }
+
+    let $spinner = $this.siblings('.repeater-spinner');
+
+    $spinner.show();
+
+    let $config = $this.siblings('[name="config"]').val();
+
+    $.ajax({
+      url: pomatio_framework_repeater.ajax_url,
+      type: 'POST',
+      data: {
+        action: 'pomatio_framework_get_repeater_item_html',
+        config: $config,
+        items: $item_count
+      },
+      success: function($response) {
+        $this.before($response);
+        $spinner.hide();
+      }
+    });
+
+    // Load custom fields as Select2 or color picker.
+    $(document).ajaxComplete(function() {
+      if (typeof $.fn.select2 !== 'undefined') {
+        $('.pomatio-framework-select.multiple').select2();
+      }
+
+      if (typeof $.fn.wpColorPicker !== 'undefined') {
+        $('.pomatio-framework-color-picker').wpColorPicker();
+      }
+
+      initializeFieldVisibility();
+    });
+  });
+
+  /**
+   * Delete repeater element.
+   *
+   * If it is a parent repeater, we directly remove it from the value using its index.
+   * If it's a child repeater, we update the value of the child repeater and then call the function to update the parent repeater.
+   * TODO: Delete file from server on delete when repeater has code fields.
+   */
+  $(document).on('click', '.repeater-wrapper .delete', function(e) {
+    e.preventDefault();
+
+    let $execute = confirm(pomatio_framework_repeater.delete_repeater);
+    if (!$execute) {
+      return;
+    }
+
+    const $this = $(this);
+    const $repeater_type = $this.closest('.repeater').hasClass('default') ? 'default' : 'new';
+    const $wrapper = $this.closest('.repeater-wrapper');
+
+    const $is_child_repeater = $wrapper.parents('.repeater-wrapper').length > 0;
+
+    if (!$is_child_repeater) {
+      const $repeater_index = $this.closest('.repeater').index();
+      let $repeater_value = $wrapper.find('.repeater-value').last().val();
+
+      $repeater_value = JSON.parse($repeater_value);
+      $repeater_value[$repeater_type].splice($repeater_index, 1);
+
+      $wrapper.find('.repeater-value').last().val(JSON.stringify($repeater_value));
+      $this.closest('.repeater').remove();
+
+      $update_repeater($wrapper);
+
+      return;
+    }
+
+    $wrapper.find('.repeater-value').val('');
+    $this.closest('.repeater').remove();
+
+    $update_repeater($wrapper);
+  });
+
+  /**
+   * Update repeater value.
+   */
+  $(document).on('change', '.repeater-wrapper input, .repeater-wrapper textarea, .repeater-wrapper select', function() {
+    const $this = $(this);
+    $update_repeater($this.closest('.repeater-wrapper'));
+  });
+
+  // Fix for Icon Picker fields
+  $(document).on('input', '.repeater-wrapper input[data-type="icon_picker"]', function() {
+    const $this = $(this);
+    $update_repeater($this.closest('.repeater-wrapper'));
+  });
+
+  /**
+   * Make WordPress Color Picker repeater compatible.
+   */
+  if (typeof $.fn.wpColorPicker !== 'undefined') {
+    $('.pomatio-framework-color-picker').wpColorPicker({
+      change: function(event, ui) {
+        let $color = ui.color.toString();
+        let $this = $(event.target);
+        $this.val($color);
+        $update_repeater($this.closest('.repeater-wrapper'));
+      }
+    });
+
+    $(document).ajaxComplete(function() {
+      $('.pomatio-framework-color-picker').wpColorPicker({
+        change: function(event, ui) {
+          let $color = ui.color.toString();
+          let $this = $(event.target);
+          $this.val($color);
+          $update_repeater($this.closest('.repeater-wrapper'));
+        }
+      });
+    });
+  }
+
+  /**
+   * Make repeater elements sortable.
+   */
+  if (typeof $.fn.sortable !== 'undefined') {
+    $('.repeater-wrapper.sortable').sortable({
+      update: function(event, ui) {
+        $update_repeater($(this));
+      }
+    });
+  }
+
+  /**
+   * Update repeater title live.
+   */
+  let $get_repeater_title_value = function($element) {
+    if ($element.is('select')) {
+      let $selected = $element.find('option:selected');
+
+      if ($selected.length > 0) {
+        let $titles = $selected
+          .map(function() {
+            return $(this).text().trim();
+          })
+          .get()
+          .filter(function(text) {
+            return text !== '';
+          });
+
+        return $titles.join(', ');
+      }
+
+      return '';
+    }
+
+    return $element.val();
+  };
+
+  let $update_repeater_title = function($element) {
+    let $title_holder = $element.closest('.repeater').find('.title span').first();
+    let $value = $get_repeater_title_value($element);
+
+    if ($value) {
+      $title_holder.html(' - ' + $value);
+    }
+    else {
+      $title_holder.html('');
+    }
+  };
+
+  $(document).on('keyup change', '.repeater .use-for-title', function() {
+    $update_repeater_title($(this));
+  });
+
+  /**
+   * Add repeater title on page load.
+   */
+  let $append_to_title = function() {
+    $('.repeater-wrapper .use-for-title').each(function(i, v) {
+      $update_repeater_title($(this));
+    });
+
+    $('.repeater-wrapper .repeater').each(function() {
+      $set_repeater_identifier($(this));
+    });
+  };
+  $append_to_title();
+  $(document).ajaxComplete(function() {
+    $append_to_title();
+  });
+
+  /**
+   * Restore repeater inputs to default value.
+   */
+  $(document).on('click', '.restore-default', function(e) {
+    e.preventDefault();
+
+    let $this = $(this);
+    let $wrapper = $this.closest('.repeater-wrapper');
+    let $repeater_defaults = $this.closest('.repeater').find('input[name="default_values"').val();
+    if ($repeater_defaults) {
+      let $decoded = JSON.parse($repeater_defaults);
+      Object.keys($decoded).map(function($key) {
+        let $value = $decoded[$key].value;
+
+        $this.closest('.repeater').find('input, select, checkbox, textarea').each(function() {
+          let $field_name = this.getAttribute('name');
+          if ($field_name === $key) {
+            this.value = $value;
+          }
+        });
+      });
+
+      $update_repeater($wrapper);
+    }
+  });
+
+  /**
+   * Restore all repeater defaults.
+   */
+  $(document).on('click', '.restore-repeater-defaults', function(e) {
+    e.preventDefault();
+
+    if (!confirm(pomatio_framework_repeater.restore_msg)) {
+      return;
+    }
+
+    let $this = $(this);
+    let $wrapper = $this.closest('.repeater-wrapper');
+
+    let $spinner = $this.closest('.repeater-wrapper').find('.repeater-spinner');
+    $spinner.show();
+
+    $wrapper.find('.repeater.default').remove();
+
+    $.ajax({
+      url: ajaxurl,
+      type: 'POST',
+      data: {
+        action: 'pomatio_framework_restore_repeater_defaults',
+        defaults: $this.attr('data-defaults'),
+        fields: $this.attr('data-fields'),
+        title: $this.attr('data-title')
+      },
+      success: function($response) {
+        $this.closest('.repeater-wrapper').prepend($response);
+        $spinner.hide();
+
+        $update_repeater($wrapper);
+      }
+    });
+  });
+
+  /**
+   * Duplicates a repeater generating a new identifier for it.
+   */
+  $(document).on('click', '.clone-repeater', function(e) {
+    e.preventDefault();
+
+    let $this = $(this);
+    let $repeater = $this.closest('.repeater');
+    let $wrapper = $this.closest('.repeater-wrapper');
+    let $clone = $repeater.clone();
+
+    /**
+     * Generate repeater new identifier.
+     */
+    $clone.find('input[name="repeater_identifier"]').val($generate_random_string(10, false));
+    $set_repeater_identifier($clone);
+
+    /**
+     * If the repeater has code fields replace their id's in order to render Codemirror with unique IDs.
+     */
+    let $code_editor = $clone.find('.pomatio-framework-code-editor-html, .pomatio-framework-code-editor-js, .pomatio-framework-code-editor-css');
+    for (let $i = 0; $i < $code_editor.length; $i++) {
+      $code_editor[$i].id = $generate_random_string(10, false);
+
+      // Delete existing code mirror instance
+      $($code_editor).next().remove();
+
+      wp.codeEditor.initialize($code_editor[$i], settings.codeMirrorSettings);
+    }
+
+    /**
+     * A cloned repeater can never be a default, so we change its key.
+     */
+    if ($clone.hasClass('default')) {
+      $clone = $clone.removeClass('default').addClass('new');
+      $clone.find('input[name="default_values"]').remove();
+    }
+
+    $repeater.after($clone);
+
+    $update_repeater($wrapper);
+  });
+
+  /**
+   * Generate a random string.
+   *
+   * The same helper exists but in PHP.
+   * @see Pomatio_Framework_Helper::generate_random_string()
+   *
+   * @param $length
+   * @param $numbers
+   * @returns {string}
+   */
+  let $generate_random_string = function($length = 10, $numbers = true) {
+    const $number_string = $numbers ? '0123456789' : '';
+    const $characters = $number_string + 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+    let $randomString = '';
+    for (let $i = 0; $i < $length; $i++) {
+      $randomString += $characters[Math.floor(Math.random() * $characters.length)];
+    }
+
+    return $randomString;
+  };
+
+});


### PR DESCRIPTION
## Summary
- ensure color palette and radio icon fields support dependencies and unique names within repeaters
- update repeater javascript to respect base field names, keep radio selections scoped per item, and evaluate dependencies reliably
- correct radio icons script handle and regenerate distributed assets

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692849de0ed4832f9e6880042391dd7a)