### PR TITLE
Handle dependencies with nested field names

### DIFF
--- a/src/Fields/Color_Palette.php
+++ b/src/Fields/Color_Palette.php
@@ -40,8 +40,9 @@ class Color_Palette {
 
                 ?>
 
-                <input type="radio" name="<?= $unique_field_name ?>" data-base-name="<?= esc_attr($args['name']) ?>" id="<?= $args['name'] . '_' . $i ?>" value="<?= $color_slug ?>" <?= $checked ?><?= $data_dependencies ?>>
-                <label style="background-color: <?= $color_data['hex'] ?? '#f3f3f3' ?>" for="<?= $args['name'] . '_' . $i ?>">
+                <?php $input_id = $unique_field_name . '_' . $i; ?>
+                <input type="radio" name="<?= $unique_field_name ?>" data-base-name="<?= esc_attr($args['name']) ?>" id="<?= $input_id ?>" value="<?= $color_slug ?>" <?= $checked ?><?= $data_dependencies ?>>
+                <label style="background-color: <?= $color_data['hex'] ?? '#f3f3f3' ?>" for="<?= $input_id ?>">
 
                     <?php
 

--- a/src/Fields/Radio_Icons.php
+++ b/src/Fields/Radio_Icons.php
@@ -41,8 +41,9 @@ class Radio_Icons {
 
                     ?>
 
+                    <?php $radio_id = $unique_field_name . '-' . $radio_value; ?>
                     <label class="icon-wrapper">
-                        <input type="radio" id="<?= $args['name'] . '-' . $radio_value ?>" name="<?= $unique_field_name ?>" data-base-name="<?= esc_attr($args['name']) ?>" value="<?= $radio_value ?>" class="form-check-input form-control <?= $args['class'] ?? '' ?>" <?= $checked ?> data-type="radio_icons"<?= $data_dependencies ?>>
+                        <input type="radio" id="<?= $radio_id ?>" name="<?= $unique_field_name ?>" data-base-name="<?= esc_attr($args['name']) ?>" value="<?= $radio_value ?>" class="form-check-input form-control <?= $args['class'] ?? '' ?>" <?= $checked ?> data-type="radio_icons"<?= $data_dependencies ?>>
                         <span class="label">
                             <span class="icon"><?= $icon ?></span>
                             <span class="description"><?= $radio_data['label'] ?></span>

--- a/src/Pomatio_Framework_Helper.php
+++ b/src/Pomatio_Framework_Helper.php
@@ -29,13 +29,8 @@ class Pomatio_Framework_Helper {
         $dependencies = !empty($args['dependency']) ? $args['dependency'] : [];
 
         if (!empty($dependencies) && is_array($dependencies)) {
-            // Encode the array into JSON format
             $jsonString = json_encode($dependencies, JSON_UNESCAPED_UNICODE | JSON_HEX_APOS);
-
-            // Replace double quotes with single quotes
-            $jsonDataAttribute = str_replace('"', "'", $jsonString);
-
-            $data_dependencies = ' data-dependencies="' . $jsonDataAttribute . '"';
+            $data_dependencies = ' data-dependencies="' . esc_attr($jsonString) . '"';
         }
 
         return $data_dependencies;

--- a/src/dist/js/repeater.js
+++ b/src/dist/js/repeater.js
@@ -29,6 +29,19 @@ jQuery(function($) {
           $dependentField = $scope.find(`[name="${fieldName}"]`);
         }
 
+        if (!$dependentField.length) {
+          $dependentField = $scope.find(`[name$="[${fieldName}]"]`);
+        }
+
+        if (!$dependentField.length) {
+          $dependentField = $scope.find(`[name$="[${fieldName}][]"]`);
+        }
+
+        if (!$dependentField.length) {
+          allConditionsMet = false;
+          break;
+        }
+
         let fieldValue = '';
 
         if ($dependentField.is(':radio')) {

--- a/src/dist/js/trbl.js
+++ b/src/dist/js/trbl.js
@@ -39,9 +39,16 @@
         }
     };
 
-    $(document).ready(function () {
-        $('.pomatio-trbl').each(function () {
+    const initTrbl = ($context = $(document)) => {
+        $context.find('.pomatio-trbl').each(function () {
             const $wrapper = $(this);
+
+            if ($wrapper.data('trbl-initialized')) {
+                return;
+            }
+
+            $wrapper.data('trbl-initialized', true);
+
             const $syncButton = $wrapper.find('.pomatio-trbl__sync');
             const $state = $wrapper.find('.pomatio-trbl__sync-state');
 
@@ -74,5 +81,13 @@
                 $wrapper.find('.pomatio-trbl__unit-select').val(unit);
             });
         });
+    };
+
+    $(document).ready(function () {
+        initTrbl();
+    });
+
+    $(document).ajaxComplete(function () {
+        initTrbl();
     });
 })(jQuery);


### PR DESCRIPTION
## Summary
- expand dependency lookup to match fields with array-style names
- prevent dependency-controlled fields from being hidden when related inputs use nested naming

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692870de47c4832fae58bda167083d22)